### PR TITLE
Gatekeeper bug fixes

### DIFF
--- a/src/api/apollo-client.ts
+++ b/src/api/apollo-client.ts
@@ -48,7 +48,16 @@ export const apolloClient = (() => {
               }),
             )
           })
-          .catch((_) => {
+          .catch((e) => {
+            console.error('Failed to refresh access token', e)
+            ;((window as any).__store as Store).dispatch(
+              showNotification({
+                header: 'Authentication failed',
+                message:
+                  "The request failed because the authentication needed to refresh, but it failed. You're being logged out",
+                type: 'red',
+              }),
+            )
             forceLogOut()
           })
       }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -13,20 +13,24 @@ const axiosInstance = axios.create({
 })
 
 export const refreshAccessToken = async () => {
-  await axios.post('/login/refresh', null, {
-    headers: {
-      accept: 'application/json',
-      'content-type': 'application/json',
-    },
-    withCredentials: true,
-  })
-  await axios.post('/api/settings/auth-success', null, {
-    headers: {
-      accept: 'application/json',
-      'content-type': 'application/json',
-    },
-    withCredentials: true,
-  })
+  if ((window as any).__hvg_refreshingAccessToken) {
+    // bail if we're already refreshing
+    return
+  }
+
+  try {
+    ;(window as any).__hvg_refreshingAccessToken = true
+    await axios.post('/login/refresh', null, {
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json',
+      },
+      withCredentials: true,
+    })
+    await axiosInstance.post('/settings/auth-success')
+  } finally {
+    ;(window as any).__hvg_refreshingAccessToken = false
+  }
 }
 
 const callApi = async (conf, data, id, params, retryCount = 0) => {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { history } from '../store'
+import { forceLogOut } from 'utils/auth'
 import config from './config'
 
 const axiosInstance = axios.create({
@@ -29,7 +29,7 @@ export const refreshAccessToken = async () => {
   })
 }
 
-const callApi = async (conf, data, id, params) => {
+const callApi = async (conf, data, id, params, retryCount = 0) => {
   try {
     return await axiosInstance.request({
       url: `${conf.url}${id ? '/' + id : ''}`,
@@ -46,11 +46,16 @@ const callApi = async (conf, data, id, params) => {
       try {
         await refreshAccessToken()
       } catch (e) {
-        history.push('/login')
+        forceLogOut()
         return
       }
 
-      return callApi(conf, data, id, params)
+      if (retryCount >= 10) {
+        forceLogOut()
+        return
+      }
+
+      return callApi(conf, data, id, params, retryCount + 1)
     }
     throw new Error(error)
   }

--- a/src/server/request-enhancers.ts
+++ b/src/server/request-enhancers.ts
@@ -1,12 +1,17 @@
 import { Middleware } from 'koa'
 
 import {
-  LoggerFactoryOptions,
   LFService,
+  Logger,
+  LoggerFactoryOptions,
   LogGroupRule,
   LogLevel,
 } from 'typescript-logging'
 import * as uuidV4 from 'uuid/v4'
+
+export interface LoggingMiddleware {
+  getLogger: (name: string) => Logger
+}
 
 const options = new LoggerFactoryOptions().addLogGroupRule(
   new LogGroupRule(/.+/, LogLevel.fromString('info')),


### PR DESCRIPTION
- Prevents infinite loops during token refresh
- Is more verbose in logging and error reporting + user feedback
- Prevents race conditions where 2 tokens were refreshed at the same time, resulting in one failing = user logged out