### PR TITLE
No longer allow chat messages to stack on iOS

### DIFF
--- a/src/components/member/messages/Message.tsx
+++ b/src/components/member/messages/Message.tsx
@@ -11,6 +11,7 @@ const MessageRow = styled.div<
   WithLeft & { isQuestion?: boolean; isVisible: boolean }
 >`
   display: flex;
+  flex-shrink: 0;
   justify-content: ${(props) => (props.left ? 'flex-end' : 'flex-start')};
   margin: ${(props) => (props.isQuestion ? '0px' : '0.5rem 0')};
   width: 100%;

--- a/src/components/member/messages/MessagesList.js
+++ b/src/components/member/messages/MessagesList.js
@@ -17,7 +17,6 @@ const MessagesListContainer = styled('div')(({ theme }) => ({
   height: '100%',
   display: 'flex',
   flexDirection: 'column-reverse',
-  flex: '1 1 0%'
 }))
 
 const EmptyList = styled('h3')({


### PR DESCRIPTION
This:
![image](https://user-images.githubusercontent.com/20777544/87047278-955b6100-c1fa-11ea-9029-a65fae073672.png)

Instead of this:
![image](https://user-images.githubusercontent.com/20777544/87047322-a4421380-c1fa-11ea-8825-a6935e3ef321.png)
