### PR TITLE
Consistent loading messages, smoother transitions

### DIFF
--- a/shared/hedvig-ui/animations/ease-in.tsx
+++ b/shared/hedvig-ui/animations/ease-in.tsx
@@ -1,0 +1,13 @@
+import styled, { keyframes } from 'react-emotion'
+
+const fadeIn = (max) =>
+  keyframes({
+    from: { opacity: 0, transform: 'translateY(2%)' },
+    to: { opacity: max, transform: 'translateY(0)' },
+  })
+
+export const EaseIn = styled('div')(() => ({
+  opacity: 0,
+  animation: `${fadeIn(1.0)} 1000ms forwards`,
+  animationDelay: '0ms',
+}))

--- a/shared/hedvig-ui/animations/ease-in.tsx
+++ b/shared/hedvig-ui/animations/ease-in.tsx
@@ -6,8 +6,10 @@ const fadeIn = (max) =>
     to: { opacity: max, transform: 'translateY(0)' },
   })
 
-export const EaseIn = styled('div')(() => ({
-  opacity: 0,
-  animation: `${fadeIn(1.0)} 1000ms forwards`,
-  animationDelay: '0ms',
-}))
+export const EaseIn = styled('div')<{ delay?: string }>(
+  ({ delay = '0ms' }) => ({
+    opacity: 0,
+    animation: `${fadeIn(1.0)} 1000ms forwards`,
+    animationDelay: delay,
+  }),
+)

--- a/shared/hedvig-ui/animations/fade-in.tsx
+++ b/shared/hedvig-ui/animations/fade-in.tsx
@@ -6,7 +6,7 @@ const fadeIn = (max) =>
     to: { opacity: max, transform: 'translateY(0)' },
   })
 
-export const EaseIn = styled('div')<{ delay?: string }>(
+export const FadeIn = styled('div')<{ delay?: string }>(
   ({ delay = '0ms' }) => ({
     opacity: 0,
     animation: `${fadeIn(1.0)} 1000ms forwards`,

--- a/shared/hedvig-ui/animations/major-message.tsx
+++ b/shared/hedvig-ui/animations/major-message.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import styled, { keyframes } from 'react-emotion'
+
+const fadeIn = (max) =>
+  keyframes({
+    from: { opacity: 0, transform: 'translateY(2%)' },
+    to: { opacity: max, transform: 'translateY(0)' },
+  })
+
+const MajorMessageWrapper = styled('div')<{
+  paddingTop?: string
+  paddingBottom?: string
+  paddingLeft?: string
+  paddingRight?: string
+}>(({ paddingTop = '25vh', paddingBottom, paddingLeft, paddingRight }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  textAlign: 'center',
+  opacity: 0,
+  animation: `${fadeIn(0.3)} 1000ms forwards`,
+  animationDelay: '20ms',
+  width: '100%',
+  flex: 1,
+  fontSize: '1.5rem',
+  paddingTop,
+  paddingBottom,
+  paddingLeft,
+  paddingRight,
+}))
+
+const AnimatedEllipsis = styled.span`
+  &::after {
+    display: inline-block;
+    animation: ellipsis 1.5s infinite;
+    content: '.';
+    width: 1em;
+    text-align: left;
+  }
+  @keyframes ellipsis {
+    0% {
+      content: '.';
+    }
+    33% {
+      content: '..';
+    }
+    66% {
+      content: '...';
+    }
+  }
+`
+
+export const MajorMessage: React.FC<{
+  children: React.ReactNode
+  paddingTop?: string
+  paddingBottom?: string
+  paddingLeft?: string
+  paddingRight?: string
+}> = ({ children, paddingTop, paddingBottom, paddingLeft, paddingRight }) => {
+  return (
+    <MajorMessageWrapper
+      paddingTop={paddingTop}
+      paddingBottom={paddingBottom}
+      paddingLeft={paddingLeft}
+      paddingRight={paddingRight}
+    >
+      {children}
+    </MajorMessageWrapper>
+  )
+}
+
+export const MajorLoadingMessage: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <MajorMessage>
+      <AnimatedEllipsis>{children}</AnimatedEllipsis>
+    </MajorMessage>
+  )
+}

--- a/shared/hedvig-ui/animations/major-message.tsx
+++ b/shared/hedvig-ui/animations/major-message.tsx
@@ -51,13 +51,21 @@ const AnimatedEllipsis = styled.span`
   }
 `
 
-export const MajorMessage: React.FC<{
+interface MajorMessageProps {
   children: React.ReactNode
   paddingTop?: string
   paddingBottom?: string
   paddingLeft?: string
   paddingRight?: string
-}> = ({ children, paddingTop, paddingBottom, paddingLeft, paddingRight }) => {
+}
+
+export const MajorMessage: React.FC<MajorMessageProps> = ({
+  children,
+  paddingTop,
+  paddingBottom,
+  paddingLeft,
+  paddingRight,
+}) => {
   return (
     <MajorMessageWrapper
       paddingTop={paddingTop}
@@ -70,11 +78,13 @@ export const MajorMessage: React.FC<{
   )
 }
 
-export const MajorLoadingMessage: React.FC<{ children: React.ReactNode }> = ({
-  children,
+export const MajorLoadingMessage: React.FC<MajorMessageProps> = ({
+  ...props
 }) => {
+  const { children, ...padding } = props
+
   return (
-    <MajorMessage>
+    <MajorMessage {...padding}>
       <AnimatedEllipsis>{children}</AnimatedEllipsis>
     </MajorMessage>
   )

--- a/shared/hedvig-ui/animations/standalone-message.tsx
+++ b/shared/hedvig-ui/animations/standalone-message.tsx
@@ -7,7 +7,7 @@ const fadeIn = (max) =>
     to: { opacity: max, transform: 'translateY(0)' },
   })
 
-const MajorMessageWrapper = styled('div')<{
+const StandaloneMessageWrapper = styled('div')<{
   paddingTop?: string
   paddingBottom?: string
   paddingLeft?: string
@@ -51,7 +51,7 @@ const AnimatedEllipsis = styled.span`
   }
 `
 
-interface MajorMessageProps {
+interface StandaloneMessageProps {
   children: React.ReactNode
   paddingTop?: string
   paddingBottom?: string
@@ -59,7 +59,7 @@ interface MajorMessageProps {
   paddingRight?: string
 }
 
-export const MajorMessage: React.FC<MajorMessageProps> = ({
+export const StandaloneMessage: React.FC<StandaloneMessageProps> = ({
   children,
   paddingTop,
   paddingBottom,
@@ -67,25 +67,25 @@ export const MajorMessage: React.FC<MajorMessageProps> = ({
   paddingRight,
 }) => {
   return (
-    <MajorMessageWrapper
+    <StandaloneMessageWrapper
       paddingTop={paddingTop}
       paddingBottom={paddingBottom}
       paddingLeft={paddingLeft}
       paddingRight={paddingRight}
     >
       {children}
-    </MajorMessageWrapper>
+    </StandaloneMessageWrapper>
   )
 }
 
-export const MajorLoadingMessage: React.FC<MajorMessageProps> = ({
+export const LoadingMessage: React.FC<StandaloneMessageProps> = ({
   ...props
 }) => {
   const { children, ...padding } = props
 
   return (
-    <MajorMessage {...padding}>
+    <StandaloneMessage {...padding}>
       <AnimatedEllipsis>{children}</AnimatedEllipsis>
-    </MajorMessage>
+    </StandaloneMessage>
   )
 }

--- a/shared/hedvig-ui/animations/standalone-message.tsx
+++ b/shared/hedvig-ui/animations/standalone-message.tsx
@@ -1,12 +1,7 @@
+import { fadeIn } from 'hedvig-ui/animations/utils'
 import { Spinner } from 'hedvig-ui/sipnner'
 import React from 'react'
-import styled, { keyframes } from 'react-emotion'
-
-const fadeIn = (max) =>
-  keyframes({
-    from: { opacity: 0, transform: 'translateY(2%)' },
-    to: { opacity: max, transform: 'translateY(0)' },
-  })
+import styled from 'react-emotion'
 
 interface StandaloneMessageProps {
   paddingTop?: string

--- a/shared/hedvig-ui/animations/standalone-message.tsx
+++ b/shared/hedvig-ui/animations/standalone-message.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from 'hedvig-ui/sipnner'
 import React from 'react'
 import styled, { keyframes } from 'react-emotion'
 
@@ -7,85 +8,46 @@ const fadeIn = (max) =>
     to: { opacity: max, transform: 'translateY(0)' },
   })
 
-const StandaloneMessageWrapper = styled('div')<{
+interface StandaloneMessageProps {
   paddingTop?: string
   paddingBottom?: string
   paddingLeft?: string
   paddingRight?: string
-}>(({ paddingTop = '25vh', paddingBottom, paddingLeft, paddingRight }) => ({
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'center',
-  alignItems: 'center',
-  textAlign: 'center',
-  opacity: 0,
-  animation: `${fadeIn(0.3)} 1000ms forwards`,
-  animationDelay: '20ms',
-  width: '100%',
-  flex: 1,
-  fontSize: '1.5rem',
-  paddingTop,
-  paddingBottom,
-  paddingLeft,
-  paddingRight,
-}))
+}
 
-const AnimatedEllipsis = styled.span`
-  &::after {
-    display: inline-block;
-    animation: ellipsis 1.5s infinite;
-    content: '.';
-    width: 1em;
-    text-align: left;
-  }
-  @keyframes ellipsis {
-    0% {
-      content: '.';
-    }
-    33% {
-      content: '..';
-    }
-    66% {
-      content: '...';
-    }
-  }
+export const StandaloneMessage = styled('div')<StandaloneMessageProps>`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  opacity: 0;
+  animation: ${fadeIn(0.3)} 1000ms forwards;
+  animation-delay: 20ms;
+  width: 100%;
+  margin: 0 auto;
+  flex: 1;
+  font-size: 1.5rem;
+  padding-top: ${({ paddingTop }) => paddingTop};
+  padding-bottom: ${({ paddingBottom }) => paddingBottom};
+  padding-left: ${({ paddingLeft }) => paddingLeft};
+  padding-right: ${({ paddingRight }) => paddingRight};
 `
 
-interface StandaloneMessageProps {
-  children: React.ReactNode
-  paddingTop?: string
-  paddingBottom?: string
-  paddingLeft?: string
-  paddingRight?: string
-}
-
-export const StandaloneMessage: React.FC<StandaloneMessageProps> = ({
-  children,
-  paddingTop,
-  paddingBottom,
-  paddingLeft,
-  paddingRight,
-}) => {
-  return (
-    <StandaloneMessageWrapper
-      paddingTop={paddingTop}
-      paddingBottom={paddingBottom}
-      paddingLeft={paddingLeft}
-      paddingRight={paddingRight}
-    >
-      {children}
-    </StandaloneMessageWrapper>
-  )
-}
+const LoadingMessageWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-left: -2em;
+`
 
 export const LoadingMessage: React.FC<StandaloneMessageProps> = ({
   ...props
-}) => {
-  const { children, ...padding } = props
-
-  return (
-    <StandaloneMessage {...padding}>
-      <AnimatedEllipsis>{children}</AnimatedEllipsis>
-    </StandaloneMessage>
-  )
-}
+}) => (
+  <StandaloneMessage {...props}>
+    <LoadingMessageWrapper>
+      <Spinner style={{ margin: '0.2em 0.7em' }} />
+      {props?.children ?? 'Loading'}
+    </LoadingMessageWrapper>
+  </StandaloneMessage>
+)

--- a/shared/hedvig-ui/animations/utils.tsx
+++ b/shared/hedvig-ui/animations/utils.tsx
@@ -1,0 +1,6 @@
+import { keyframes } from 'react-emotion'
+
+export const fadeIn = (max: number) => keyframes`
+  from { opacity: 0; transform: translateY(2%) }
+  to { opacity: ${max}; transform: translateY(0) }
+`

--- a/src/components/claims/claim-details/index.tsx
+++ b/src/components/claims/claim-details/index.tsx
@@ -2,6 +2,7 @@ import Grid from '@material-ui/core/Grid'
 import { ClaimNote, ClaimTranscription, QueryType } from 'api/generated/graphql'
 import { ClaimItems } from 'components/claims/claim-details/components/claim-items'
 import { ChatPane } from 'components/member/tabs/ChatPane'
+import { EaseIn } from 'hedvig-ui/animations/ease-in'
 import { MajorLoadingMessage } from 'hedvig-ui/animations/major-message'
 import React from 'react'
 import { Query } from 'react-apollo'
@@ -42,11 +43,7 @@ const ClaimPage: React.FC<Props> = ({ ...props }) => (
           >
             {({ loading, error, data, refetch }) => {
               if (loading) {
-                return (
-                  <MajorLoadingMessage paddingTop="10vh">
-                    Loading
-                  </MajorLoadingMessage>
-                )
+                return <MajorLoadingMessage>Loading</MajorLoadingMessage>
               }
 
               const {
@@ -66,99 +63,103 @@ const ClaimPage: React.FC<Props> = ({ ...props }) => (
               } = data?.claim || {}
 
               return (
-                <Grid container spacing={8}>
-                  <Prompt
-                    when={Boolean(data?.claim) && !reserves}
-                    message="This claim has no reserves, do you want leave it it without?"
-                  />
-                  {error && (
-                    <Grid item xs={12}>
-                      <div>
-                        Error: <pre>{JSON.stringify(error, null, 2)}</pre>
-                      </div>
-                    </Grid>
-                  )}
+                <EaseIn>
+                  <Grid container spacing={8}>
+                    <Prompt
+                      when={Boolean(data?.claim) && !reserves}
+                      message="This claim has no reserves, do you want leave it it without?"
+                    />
+                    {error && (
+                      <Grid item xs={12}>
+                        <div>
+                          Error: <pre>{JSON.stringify(error, null, 2)}</pre>
+                        </div>
+                      </Grid>
+                    )}
 
-                  <Grid item xs={12} sm={12} md={4}>
-                    {member && (
-                      <MemberInformation
-                        member={member}
-                        contract={contract ?? null}
+                    <Grid item xs={12} sm={12} md={4}>
+                      {member && (
+                        <MemberInformation
+                          member={member}
+                          contract={contract ?? null}
+                        />
+                      )}
+                    </Grid>
+                    <Grid item xs={12} sm={12} md={4}>
+                      <ClaimInformation
+                        recordingUrl={recordingUrl!}
+                        registrationDate={registrationDate}
+                        state={state!}
+                        claimId={props.match.params.claimId}
+                        coveringEmployee={coveringEmployee!}
+                        memberId={props.match.params.memberId}
+                        refetchPage={refetch}
+                        selectedContract={contract!}
                       />
-                    )}
-                  </Grid>
-                  <Grid item xs={12} sm={12} md={4}>
-                    <ClaimInformation
-                      recordingUrl={recordingUrl!}
-                      registrationDate={registrationDate}
-                      state={state!}
-                      claimId={props.match.params.claimId}
-                      coveringEmployee={coveringEmployee!}
-                      memberId={props.match.params.memberId}
-                      refetchPage={refetch}
-                      selectedContract={contract!}
-                    />
-                  </Grid>
-                  <Grid item xs={12} sm={12} md={4}>
-                    <ClaimTypeForm
-                      type={type}
-                      claimId={props.match.params.claimId}
-                      refetchPage={refetch}
-                    />
-                  </Grid>
-                  <Grid item xs={12}>
-                    {transcriptions && transcriptions.length > 0 && (
-                      <ClaimTranscriptions
-                        transcriptions={transcriptions as ClaimTranscription[]}
-                      />
-                    )}
-                  </Grid>
-                  <Grid item xs={12}>
-                    {notes && (
-                      <ClaimNotes
-                        notes={(notes.filter(Boolean) as ClaimNote[]) ?? []}
+                    </Grid>
+                    <Grid item xs={12} sm={12} md={4}>
+                      <ClaimTypeForm
+                        type={type}
                         claimId={props.match.params.claimId}
                         refetchPage={refetch}
                       />
-                    )}
-                  </Grid>
-                  <Grid item xs={12}>
-                    <ClaimItems
-                      claimId={props.match.params.claimId}
-                      memberId={member?.memberId ?? null}
-                      contract={contract}
-                    />
-                  </Grid>
-                  <Grid item xs={12}>
-                    {payments && member && (
-                      <ClaimPayments
-                        payments={payments ?? []}
+                    </Grid>
+                    <Grid item xs={12}>
+                      {transcriptions && transcriptions.length > 0 && (
+                        <ClaimTranscriptions
+                          transcriptions={
+                            transcriptions as ClaimTranscription[]
+                          }
+                        />
+                      )}
+                    </Grid>
+                    <Grid item xs={12}>
+                      {notes && (
+                        <ClaimNotes
+                          notes={(notes.filter(Boolean) as ClaimNote[]) ?? []}
+                          claimId={props.match.params.claimId}
+                          refetchPage={refetch}
+                        />
+                      )}
+                    </Grid>
+                    <Grid item xs={12}>
+                      <ClaimItems
                         claimId={props.match.params.claimId}
-                        reserves={reserves}
-                        sanctionStatus={member.sanctionStatus!}
-                        refetchPage={refetch}
+                        memberId={member?.memberId ?? null}
+                        contract={contract}
                       />
-                    )}
+                    </Grid>
+                    <Grid item xs={12}>
+                      {payments && member && (
+                        <ClaimPayments
+                          payments={payments ?? []}
+                          claimId={props.match.params.claimId}
+                          reserves={reserves}
+                          sanctionStatus={member.sanctionStatus!}
+                          refetchPage={refetch}
+                        />
+                      )}
+                    </Grid>
+                    <Grid item xs={12}>
+                      {member && (
+                        <FileUpload
+                          claimId={props.match.params.claimId}
+                          memberId={member.memberId}
+                          onUploaded={() => refetch()}
+                        />
+                      )}
+                      {claimFiles && (
+                        <ClaimFileTable
+                          claimFiles={claimFiles ?? []}
+                          claimId={props.match.params.claimId}
+                        />
+                      )}
+                    </Grid>
+                    <Grid item xs={12}>
+                      {events && <ClaimEvents events={events ?? []} />}
+                    </Grid>
                   </Grid>
-                  <Grid item xs={12}>
-                    {member && (
-                      <FileUpload
-                        claimId={props.match.params.claimId}
-                        memberId={member.memberId}
-                        onUploaded={() => refetch()}
-                      />
-                    )}
-                    {claimFiles && (
-                      <ClaimFileTable
-                        claimFiles={claimFiles ?? []}
-                        claimId={props.match.params.claimId}
-                      />
-                    )}
-                  </Grid>
-                  <Grid item xs={12}>
-                    {events && <ClaimEvents events={events ?? []} />}
-                  </Grid>
-                </Grid>
+                </EaseIn>
               )
             }}
           </Query>

--- a/src/components/claims/claim-details/index.tsx
+++ b/src/components/claims/claim-details/index.tsx
@@ -3,7 +3,7 @@ import { ClaimNote, ClaimTranscription, QueryType } from 'api/generated/graphql'
 import { ClaimItems } from 'components/claims/claim-details/components/claim-items'
 import { ChatPane } from 'components/member/tabs/ChatPane'
 import { EaseIn } from 'hedvig-ui/animations/ease-in'
-import { MajorLoadingMessage } from 'hedvig-ui/animations/major-message'
+import { LoadingMessage } from 'hedvig-ui/animations/standalone-message'
 import React from 'react'
 import { Query } from 'react-apollo'
 import { Mount } from 'react-lifecycle-components/dist'
@@ -43,7 +43,7 @@ const ClaimPage: React.FC<Props> = ({ ...props }) => (
           >
             {({ loading, error, data, refetch }) => {
               if (loading) {
-                return <MajorLoadingMessage>Loading</MajorLoadingMessage>
+                return <LoadingMessage>Loading</LoadingMessage>
               }
 
               const {

--- a/src/components/claims/claim-details/index.tsx
+++ b/src/components/claims/claim-details/index.tsx
@@ -2,6 +2,7 @@ import Grid from '@material-ui/core/Grid'
 import { ClaimNote, ClaimTranscription, QueryType } from 'api/generated/graphql'
 import { ClaimItems } from 'components/claims/claim-details/components/claim-items'
 import { ChatPane } from 'components/member/tabs/ChatPane'
+import { MajorLoadingMessage } from 'hedvig-ui/animations/major-message'
 import React from 'react'
 import { Query } from 'react-apollo'
 import { Mount } from 'react-lifecycle-components/dist'
@@ -41,7 +42,11 @@ const ClaimPage: React.FC<Props> = ({ ...props }) => (
           >
             {({ loading, error, data, refetch }) => {
               if (loading) {
-                return <div>Loading</div>
+                return (
+                  <MajorLoadingMessage paddingTop="10vh">
+                    Loading
+                  </MajorLoadingMessage>
+                )
               }
 
               const {

--- a/src/components/claims/claim-details/index.tsx
+++ b/src/components/claims/claim-details/index.tsx
@@ -2,7 +2,7 @@ import Grid from '@material-ui/core/Grid'
 import { ClaimNote, ClaimTranscription, QueryType } from 'api/generated/graphql'
 import { ClaimItems } from 'components/claims/claim-details/components/claim-items'
 import { ChatPane } from 'components/member/tabs/ChatPane'
-import { EaseIn } from 'hedvig-ui/animations/ease-in'
+import { FadeIn } from 'hedvig-ui/animations/fade-in'
 import { LoadingMessage } from 'hedvig-ui/animations/standalone-message'
 import React from 'react'
 import { Query } from 'react-apollo'
@@ -63,7 +63,7 @@ const ClaimPage: React.FC<Props> = ({ ...props }) => (
               } = data?.claim || {}
 
               return (
-                <EaseIn>
+                <FadeIn>
                   <Grid container spacing={8}>
                     <Prompt
                       when={Boolean(data?.claim) && !reserves}
@@ -159,7 +159,7 @@ const ClaimPage: React.FC<Props> = ({ ...props }) => (
                       {events && <ClaimEvents events={events ?? []} />}
                     </Grid>
                   </Grid>
-                </EaseIn>
+                </FadeIn>
               )
             }}
           </Query>

--- a/src/components/claims/claim-details/index.tsx
+++ b/src/components/claims/claim-details/index.tsx
@@ -42,8 +42,8 @@ const ClaimPage: React.FC<Props> = ({ ...props }) => (
             fetchPolicy="no-cache"
           >
             {({ loading, error, data, refetch }) => {
-              if (loading) {
-                return <LoadingMessage>Loading</LoadingMessage>
+              if (!loading) {
+                return <LoadingMessage paddingTop="25vh" />
               }
 
               const {

--- a/src/components/claims/index.tsx
+++ b/src/components/claims/index.tsx
@@ -1,7 +1,7 @@
+import { MajorLoadingMessage } from 'hedvig-ui/animations/major-message'
 import React from 'react'
-import { Mount } from 'react-lifecycle-components/dist'
 import { Header } from 'semantic-ui-react'
-import { ClaimSearchFilter, ClaimsStore } from '../../store/types/claimsTypes'
+import { ClaimSearchFilter, ClaimsStore } from 'store/types/claimsTypes'
 import BackendServedClaimsList from './claims-list/BackendServedClaimsList'
 
 export interface ClaimsProps {
@@ -9,18 +9,24 @@ export interface ClaimsProps {
   claimsRequest: (filter: ClaimSearchFilter) => void
 }
 
-const Claims: React.SFC<ClaimsProps> = (props) => {
+const Claims: React.FC<ClaimsProps> = (props) => {
   const { claimsRequest, claims } = props
 
   const initClaims = () => claimsRequest(claims.searchFilter)
 
+  React.useEffect(() => {
+    initClaims()
+  }, [])
+
+  if (claims.searchResult.claims.length === 0) {
+    return <MajorLoadingMessage>Loading</MajorLoadingMessage>
+  }
+
   return (
-    <Mount on={initClaims}>
-      <React.Fragment>
-        <Header size="huge">Claims List</Header>
-        <BackendServedClaimsList {...props} />
-      </React.Fragment>
-    </Mount>
+    <>
+      <Header size="huge">Claims List</Header>
+      <BackendServedClaimsList {...props} />
+    </>
   )
 }
 

--- a/src/components/claims/index.tsx
+++ b/src/components/claims/index.tsx
@@ -1,4 +1,4 @@
-import { EaseIn } from 'hedvig-ui/animations/ease-in'
+import { FadeIn } from 'hedvig-ui/animations/fade-in'
 import { LoadingMessage } from 'hedvig-ui/animations/standalone-message'
 import { Spacing } from 'hedvig-ui/spacing'
 import React from 'react'
@@ -26,13 +26,13 @@ const Claims: React.FC<ClaimsProps> = (props) => {
 
   return (
     <>
-      <EaseIn>
+      <FadeIn>
         <Header size="huge">Claims List</Header>
-      </EaseIn>
+      </FadeIn>
       <Spacing top={'small'}>
-        <EaseIn delay={'200ms'}>
+        <FadeIn delay={'200ms'}>
           <BackendServedClaimsList {...props} />
-        </EaseIn>
+        </FadeIn>
       </Spacing>
     </>
   )

--- a/src/components/claims/index.tsx
+++ b/src/components/claims/index.tsx
@@ -21,7 +21,7 @@ const Claims: React.FC<ClaimsProps> = (props) => {
   }, [])
 
   if (claims.searchResult.claims.length === 0) {
-    return <LoadingMessage>Loading</LoadingMessage>
+    return <LoadingMessage paddingTop={'25vh'} />
   }
 
   return (

--- a/src/components/claims/index.tsx
+++ b/src/components/claims/index.tsx
@@ -1,5 +1,5 @@
 import { EaseIn } from 'hedvig-ui/animations/ease-in'
-import { MajorLoadingMessage } from 'hedvig-ui/animations/major-message'
+import { LoadingMessage } from 'hedvig-ui/animations/standalone-message'
 import { Spacing } from 'hedvig-ui/spacing'
 import React from 'react'
 import { Header } from 'semantic-ui-react'
@@ -21,7 +21,7 @@ const Claims: React.FC<ClaimsProps> = (props) => {
   }, [])
 
   if (claims.searchResult.claims.length === 0) {
-    return <MajorLoadingMessage>Loading</MajorLoadingMessage>
+    return <LoadingMessage>Loading</LoadingMessage>
   }
 
   return (

--- a/src/components/claims/index.tsx
+++ b/src/components/claims/index.tsx
@@ -1,4 +1,6 @@
+import { EaseIn } from 'hedvig-ui/animations/ease-in'
 import { MajorLoadingMessage } from 'hedvig-ui/animations/major-message'
+import { Spacing } from 'hedvig-ui/spacing'
 import React from 'react'
 import { Header } from 'semantic-ui-react'
 import { ClaimSearchFilter, ClaimsStore } from 'store/types/claimsTypes'
@@ -24,8 +26,14 @@ const Claims: React.FC<ClaimsProps> = (props) => {
 
   return (
     <>
-      <Header size="huge">Claims List</Header>
-      <BackendServedClaimsList {...props} />
+      <EaseIn>
+        <Header size="huge">Claims List</Header>
+      </EaseIn>
+      <Spacing top={'small'}>
+        <EaseIn delay={'200ms'}>
+          <BackendServedClaimsList {...props} />
+        </EaseIn>
+      </Spacing>
     </>
   )
 }

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -1,6 +1,7 @@
 import { changelog } from 'changelog'
 import { differenceInCalendarDays, format } from 'date-fns'
 import { useDashboardNumbers } from 'graphql/use-dashboard-numbers'
+import { EaseIn } from 'hedvig-ui/animations/ease-in'
 import { Badge } from 'hedvig-ui/badge'
 import { CasualList, CasualListItem } from 'hedvig-ui/casual-list'
 import { Spacing } from 'hedvig-ui/spacing'
@@ -67,18 +68,22 @@ export const Dashboard: React.FC<{ auth: any }> = ({ auth }) => {
         !
       </Headline>
       {dashboardNumbers && (
-        <MetricsWrapper>
-          <Metric to="/claims">
-            <MetricNumber>{dashboardNumbers?.numberOfClaims || 0}</MetricNumber>
-            <MetricName>claims</MetricName>
-          </Metric>
-          <Metric to="/questions">
-            <MetricNumber>
-              {dashboardNumbers?.numberOfQuestions || 0}
-            </MetricNumber>
-            <MetricName>questions</MetricName>
-          </Metric>
-        </MetricsWrapper>
+        <EaseIn>
+          <MetricsWrapper>
+            <Metric to="/claims">
+              <MetricNumber>
+                {dashboardNumbers?.numberOfClaims || 0}
+              </MetricNumber>
+              <MetricName>claims</MetricName>
+            </Metric>
+            <Metric to="/questions">
+              <MetricNumber>
+                {dashboardNumbers?.numberOfQuestions || 0}
+              </MetricNumber>
+              <MetricName>questions</MetricName>
+            </Metric>
+          </MetricsWrapper>
+        </EaseIn>
       )}
       <Spacing top="large">
         <SecondLevelHeadline>Recent changes from Tech</SecondLevelHeadline>
@@ -91,27 +96,29 @@ export const Dashboard: React.FC<{ auth: any }> = ({ auth }) => {
           </MutedText>
         </Spacing>
         <ChangeLogWrapper>
-          {changelog.slice(0, 10).map((change) => {
+          {changelog.slice(0, 10).map((change, index) => {
             const isRecent =
               differenceInCalendarDays(new Date(), change.date) < 3
             return (
-              <ChangeLogItem key={change.change}>
-                <ChangeDescription>
-                  {change.change}
-                  {isRecent && (
-                    <Spacing inline left="small" width="auto">
-                      <Badge variant="success" size="small" matchParentSize>
-                        New!
-                      </Badge>
-                    </Spacing>
-                  )}
-                </ChangeDescription>
-                <MutedText>
-                  {format(change.date, 'iii MMM do')}
-                  {change.authorGithubHandle &&
-                    ` by ${change.authorGithubHandle}`}
-                </MutedText>
-              </ChangeLogItem>
+              <EaseIn delay={`${index * 50}ms`}>
+                <ChangeLogItem key={change.change}>
+                  <ChangeDescription>
+                    {change.change}
+                    {isRecent && (
+                      <Spacing inline left="small" width="auto">
+                        <Badge variant="success" size="small" matchParentSize>
+                          New!
+                        </Badge>
+                      </Spacing>
+                    )}
+                  </ChangeDescription>
+                  <MutedText>
+                    {format(change.date, 'iii MMM do')}
+                    {change.authorGithubHandle &&
+                      ` by ${change.authorGithubHandle}`}
+                  </MutedText>
+                </ChangeLogItem>
+              </EaseIn>
             )
           })}
         </ChangeLogWrapper>

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -1,7 +1,7 @@
 import { changelog } from 'changelog'
 import { differenceInCalendarDays, format } from 'date-fns'
 import { useDashboardNumbers } from 'graphql/use-dashboard-numbers'
-import { EaseIn } from 'hedvig-ui/animations/ease-in'
+import { FadeIn } from 'hedvig-ui/animations/fade-in'
 import { Badge } from 'hedvig-ui/badge'
 import { CasualList, CasualListItem } from 'hedvig-ui/casual-list'
 import { Spacing } from 'hedvig-ui/spacing'
@@ -68,7 +68,7 @@ export const Dashboard: React.FC<{ auth: any }> = ({ auth }) => {
         !
       </Headline>
       {dashboardNumbers && (
-        <EaseIn>
+        <FadeIn>
           <MetricsWrapper>
             <Metric to="/claims">
               <MetricNumber>
@@ -83,7 +83,7 @@ export const Dashboard: React.FC<{ auth: any }> = ({ auth }) => {
               <MetricName>questions</MetricName>
             </Metric>
           </MetricsWrapper>
-        </EaseIn>
+        </FadeIn>
       )}
       <Spacing top="large">
         <SecondLevelHeadline>Recent changes from Tech</SecondLevelHeadline>
@@ -100,7 +100,7 @@ export const Dashboard: React.FC<{ auth: any }> = ({ auth }) => {
             const isRecent =
               differenceInCalendarDays(new Date(), change.date) < 3
             return (
-              <EaseIn delay={`${index * 50}ms`}>
+              <FadeIn delay={`${index * 50}ms`}>
                 <ChangeLogItem key={change.change}>
                   <ChangeDescription>
                     {change.change}
@@ -118,7 +118,7 @@ export const Dashboard: React.FC<{ auth: any }> = ({ auth }) => {
                       ` by ${change.authorGithubHandle}`}
                   </MutedText>
                 </ChangeLogItem>
-              </EaseIn>
+              </FadeIn>
             )
           })}
         </ChangeLogWrapper>

--- a/src/components/member/index.js
+++ b/src/components/member/index.js
@@ -3,6 +3,7 @@ import { Popover } from 'hedvig-ui/popover'
 import { FraudulentStatus } from 'lib/fraudulentStatus'
 import * as PropTypes from 'prop-types'
 import * as React from 'react'
+import { useEffect } from 'react'
 import styled from 'react-emotion'
 import { Header as SemanticHeader, Tab } from 'semantic-ui-react'
 import {
@@ -11,11 +12,10 @@ import {
   getMemberIdColor,
   MemberAge,
 } from 'utils/member'
-import memberPagePanes from './tabs'
+import memberPagePanes from './tabs/index'
 import { MemberFlag } from './shared/member-flag'
-import { MemberHistoryContext } from '../../utils/member-history'
+import { MemberHistoryContext } from 'utils/member-history'
 import { Mount } from 'react-lifecycle-components/dist'
-import { useEffect } from 'react'
 import { useGetMemberInfo } from 'graphql/use-get-member-info'
 import { ChatPane } from 'components/member/tabs/ChatPane'
 

--- a/src/components/member/tabs/ClaimsTab.tsx
+++ b/src/components/member/tabs/ClaimsTab.tsx
@@ -7,6 +7,7 @@ import MaterialModal from 'components/shared/modals/MaterialModal'
 import { ActionMap, Container } from 'constate'
 import { format } from 'date-fns'
 import gql from 'graphql-tag'
+import { MajorMessage } from 'hedvig-ui/animations/major-message'
 import { DateTimePicker } from 'hedvig-ui/date-time-picker'
 import * as React from 'react'
 import { Mutation } from 'react-apollo'
@@ -138,9 +139,7 @@ const ClaimsTab: React.FC<ClaimsTabProps> = (props) => {
               sortClaimsList={props.sortClaimsList}
             />
           ) : (
-            <Typography variant="h5" component="h3">
-              Claims list is empty
-            </Typography>
+            <MajorMessage paddingTop="10vh">Claims list is empty</MajorMessage>
           )}
           <MaterialModal handleClose={handleClose} open={open}>
             <Typography variant="h5" id="modal-title">

--- a/src/components/member/tabs/ClaimsTab.tsx
+++ b/src/components/member/tabs/ClaimsTab.tsx
@@ -7,9 +7,10 @@ import MaterialModal from 'components/shared/modals/MaterialModal'
 import { ActionMap, Container } from 'constate'
 import { format } from 'date-fns'
 import gql from 'graphql-tag'
+import { EaseIn } from 'hedvig-ui/animations/ease-in'
 import { MajorMessage } from 'hedvig-ui/animations/major-message'
 import { DateTimePicker } from 'hedvig-ui/date-time-picker'
-import * as React from 'react'
+import React from 'react'
 import { Mutation } from 'react-apollo'
 import styled, { css } from 'react-emotion'
 import { history } from 'store'
@@ -81,116 +82,120 @@ interface Actions {
 
 const ClaimsTab: React.FC<ClaimsTabProps> = (props) => {
   return (
-    <Container<State, ActionMap<State, Actions>>
-      initialState={{
-        open: false,
-        date: new Date(),
-        value: 'EMAIL',
-      }}
-      actions={{
-        handleClose: () => (_) => ({ open: false }),
-        handleOpen: () => (_) => ({ open: true }),
-        handleClaimSubmit: (mutation) => (state) => {
-          mutation({
-            variables: {
-              memberId: props.memberId,
-              date: format(state.date, "yyyy-MM-dd'T'HH:mm:ss"),
-              source: state.value,
-            },
-          }).then((response) => {
-            history.push(
-              `/claims/${response.data.createClaim}/members/${props.memberId}`,
-            )
-          })
-          return { date: new Date(), value: 'EMAIL', open: false }
-        },
-        typeChangeHandler: (event) => (_) => ({
-          value: event.target.value,
-        }),
-        dateChangeHandler: (date) => {
-          return {
-            date,
-          }
-        },
-      }}
-    >
-      {({
-        handleClose,
-        handleOpen,
-        dateChangeHandler,
-        typeChangeHandler,
-        handleClaimSubmit,
-        open,
-        value,
-        date,
-      }) => (
-        <>
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={handleOpen}
-            className={buttonStyle}
-          >
-            Add new claim
-          </Button>
-          {props.memberClaims.length > 0 ? (
-            <ClaimsList
-              claims={{ list: props.memberClaims }}
-              sortClaimsList={props.sortClaimsList}
-            />
-          ) : (
-            <MajorMessage paddingTop="10vh">Claims list is empty</MajorMessage>
-          )}
-          <MaterialModal handleClose={handleClose} open={open}>
-            <Typography variant="h5" id="modal-title">
-              Create claim
-            </Typography>
-            <Typography variant="subtitle1" id="simple-modal-description">
-              Choose notification date and type of claim.
-            </Typography>
-            <InlineFlex>
-              <TextField
-                id="filled-select-currency"
-                select
-                label="Select"
-                value={value}
-                onChange={typeChangeHandler}
-                helperText="Please select claim type"
-                margin="normal"
-                variant="filled"
-              >
-                {types.map((option) => (
-                  <MenuItem key={option.value} value={option.value}>
-                    {option.label}
-                  </MenuItem>
-                ))}
-              </TextField>
-              <strong>Notification date</strong>
-              <DateTimePicker
-                date={date}
-                setDate={dateChangeHandler as any}
-                placeholder="Notification date"
-                maxDate={new Date()}
+    <EaseIn>
+      <Container<State, ActionMap<State, Actions>>
+        initialState={{
+          open: false,
+          date: new Date(),
+          value: 'EMAIL',
+        }}
+        actions={{
+          handleClose: () => (_) => ({ open: false }),
+          handleOpen: () => (_) => ({ open: true }),
+          handleClaimSubmit: (mutation) => (state) => {
+            mutation({
+              variables: {
+                memberId: props.memberId,
+                date: format(state.date, "yyyy-MM-dd'T'HH:mm:ss"),
+                source: state.value,
+              },
+            }).then((response) => {
+              history.push(
+                `/claims/${response.data.createClaim}/members/${props.memberId}`,
+              )
+            })
+            return { date: new Date(), value: 'EMAIL', open: false }
+          },
+          typeChangeHandler: (event) => (_) => ({
+            value: event.target.value,
+          }),
+          dateChangeHandler: (date) => {
+            return {
+              date,
+            }
+          },
+        }}
+      >
+        {({
+          handleClose,
+          handleOpen,
+          dateChangeHandler,
+          typeChangeHandler,
+          handleClaimSubmit,
+          open,
+          value,
+          date,
+        }) => (
+          <>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleOpen}
+              className={buttonStyle}
+            >
+              Add new claim
+            </Button>
+            {props.memberClaims.length > 0 ? (
+              <ClaimsList
+                claims={{ list: props.memberClaims }}
+                sortClaimsList={props.sortClaimsList}
               />
-            </InlineFlex>
-            <InlineFlexButton>
-              <Mutation mutation={CREATE_CLAIM_MUTATION}>
-                {(createClaim) => (
-                  <Button
-                    variant="contained"
-                    color="secondary"
-                    onClick={() => handleClaimSubmit(createClaim)}
-                    className={buttonStyle}
-                  >
-                    Save
-                  </Button>
-                )}
-              </Mutation>
-            </InlineFlexButton>
-          </MaterialModal>
-        </>
-      )}
-    </Container>
+            ) : (
+              <MajorMessage paddingTop="10vh">
+                Claims list is empty
+              </MajorMessage>
+            )}
+            <MaterialModal handleClose={handleClose} open={open}>
+              <Typography variant="h5" id="modal-title">
+                Create claim
+              </Typography>
+              <Typography variant="subtitle1" id="simple-modal-description">
+                Choose notification date and type of claim.
+              </Typography>
+              <InlineFlex>
+                <TextField
+                  id="filled-select-currency"
+                  select
+                  label="Select"
+                  value={value}
+                  onChange={typeChangeHandler}
+                  helperText="Please select claim type"
+                  margin="normal"
+                  variant="filled"
+                >
+                  {types.map((option) => (
+                    <MenuItem key={option.value} value={option.value}>
+                      {option.label}
+                    </MenuItem>
+                  ))}
+                </TextField>
+                <strong>Notification date</strong>
+                <DateTimePicker
+                  date={date}
+                  setDate={dateChangeHandler as any}
+                  placeholder="Notification date"
+                  maxDate={new Date()}
+                />
+              </InlineFlex>
+              <InlineFlexButton>
+                <Mutation mutation={CREATE_CLAIM_MUTATION}>
+                  {(createClaim) => (
+                    <Button
+                      variant="contained"
+                      color="secondary"
+                      onClick={() => handleClaimSubmit(createClaim)}
+                      className={buttonStyle}
+                    >
+                      Save
+                    </Button>
+                  )}
+                </Mutation>
+              </InlineFlexButton>
+            </MaterialModal>
+          </>
+        )}
+      </Container>
+    </EaseIn>
   )
 }
 

--- a/src/components/member/tabs/ClaimsTab.tsx
+++ b/src/components/member/tabs/ClaimsTab.tsx
@@ -8,7 +8,7 @@ import { ActionMap, Container } from 'constate'
 import { format } from 'date-fns'
 import gql from 'graphql-tag'
 import { EaseIn } from 'hedvig-ui/animations/ease-in'
-import { MajorMessage } from 'hedvig-ui/animations/major-message'
+import { StandaloneMessage } from 'hedvig-ui/animations/standalone-message'
 import { DateTimePicker } from 'hedvig-ui/date-time-picker'
 import React from 'react'
 import { Mutation } from 'react-apollo'
@@ -141,9 +141,9 @@ const ClaimsTab: React.FC<ClaimsTabProps> = (props) => {
                 sortClaimsList={props.sortClaimsList}
               />
             ) : (
-              <MajorMessage paddingTop="10vh">
+              <StandaloneMessage paddingTop="10vh">
                 Claims list is empty
-              </MajorMessage>
+              </StandaloneMessage>
             )}
             <MaterialModal handleClose={handleClose} open={open}>
               <Typography variant="h5" id="modal-title">

--- a/src/components/member/tabs/ClaimsTab.tsx
+++ b/src/components/member/tabs/ClaimsTab.tsx
@@ -7,7 +7,7 @@ import MaterialModal from 'components/shared/modals/MaterialModal'
 import { ActionMap, Container } from 'constate'
 import { format } from 'date-fns'
 import gql from 'graphql-tag'
-import { EaseIn } from 'hedvig-ui/animations/ease-in'
+import { FadeIn } from 'hedvig-ui/animations/fade-in'
 import { StandaloneMessage } from 'hedvig-ui/animations/standalone-message'
 import { DateTimePicker } from 'hedvig-ui/date-time-picker'
 import React from 'react'
@@ -82,7 +82,7 @@ interface Actions {
 
 const ClaimsTab: React.FC<ClaimsTabProps> = (props) => {
   return (
-    <EaseIn>
+    <FadeIn>
       <Container<State, ActionMap<State, Actions>>
         initialState={{
           open: false,
@@ -195,7 +195,7 @@ const ClaimsTab: React.FC<ClaimsTabProps> = (props) => {
           </>
         )}
       </Container>
-    </EaseIn>
+    </FadeIn>
   )
 }
 

--- a/src/components/member/tabs/DetailsTab.js
+++ b/src/components/member/tabs/DetailsTab.js
@@ -16,7 +16,7 @@ import {
   useSetFraudulentStatus,
 } from 'graphql/use-set-fraudulent-status'
 import { withShowNotification } from 'utils/notifications'
-import { EaseIn } from 'hedvig-ui/animations/ease-in'
+import { FadeIn } from 'hedvig-ui/animations/fade-in'
 
 const memberFieldFormatters = {
   signedOn: (date) => dateTimeFormatter(date, 'yyyy-MM-dd HH:mm:ss'),
@@ -86,7 +86,7 @@ const DetailsTabComponent = (props) => {
   delete memberInfoWithoutSsn.__typename
 
   return memberInfoWithoutSsn ? (
-    <EaseIn>
+    <FadeIn>
       <Table selectable>
         <Table.Body>
           <TableFields
@@ -187,7 +187,7 @@ const DetailsTabComponent = (props) => {
         </Table.Footer>
       </Table>
       <InsuranceTrace traceData={traceMemberInfo} />
-    </EaseIn>
+    </FadeIn>
   ) : (
     <Header>No member info</Header>
   )

--- a/src/components/member/tabs/DetailsTab.js
+++ b/src/components/member/tabs/DetailsTab.js
@@ -16,6 +16,7 @@ import {
   useSetFraudulentStatus,
 } from 'graphql/use-set-fraudulent-status'
 import { withShowNotification } from 'utils/notifications'
+import { EaseIn } from 'hedvig-ui/animations/ease-in'
 
 const memberFieldFormatters = {
   signedOn: (date) => dateTimeFormatter(date, 'yyyy-MM-dd HH:mm:ss'),
@@ -85,7 +86,7 @@ const DetailsTabComponent = (props) => {
   delete memberInfoWithoutSsn.__typename
 
   return memberInfoWithoutSsn ? (
-    <>
+    <EaseIn>
       <Table selectable>
         <Table.Body>
           <TableFields
@@ -186,7 +187,7 @@ const DetailsTabComponent = (props) => {
         </Table.Footer>
       </Table>
       <InsuranceTrace traceData={traceMemberInfo} />
-    </>
+    </EaseIn>
   ) : (
     <Header>No member info</Header>
   )

--- a/src/components/member/tabs/FileTab.tsx
+++ b/src/components/member/tabs/FileTab.tsx
@@ -1,9 +1,9 @@
 import gql from 'graphql-tag'
 import { EaseIn } from 'hedvig-ui/animations/ease-in'
 import {
-  MajorLoadingMessage,
-  MajorMessage,
-} from 'hedvig-ui/animations/major-message'
+  LoadingMessage,
+  StandaloneMessage,
+} from 'hedvig-ui/animations/standalone-message'
 import { dateTimeFormatter } from 'lib/helpers'
 import React from 'react'
 import { Query } from 'react-apollo'
@@ -91,17 +91,13 @@ class MemberFile extends React.Component<
               )
             }
             if (loading || !data) {
-              return (
-                <MajorLoadingMessage paddingTop="10vh">
-                  Loading
-                </MajorLoadingMessage>
-              )
+              return <LoadingMessage paddingTop="10vh">Loading</LoadingMessage>
             }
 
             return data.member.fileUploads.length === 0 ? (
-              <MajorMessage paddingTop="10vh">
+              <StandaloneMessage paddingTop="10vh">
                 No files uploaded for this member
-              </MajorMessage>
+              </StandaloneMessage>
             ) : (
               <MemberFileTable memberFiles={data.member.fileUploads} />
             )

--- a/src/components/member/tabs/FileTab.tsx
+++ b/src/components/member/tabs/FileTab.tsx
@@ -91,7 +91,7 @@ class MemberFile extends React.Component<
               )
             }
             if (loading || !data) {
-              return <LoadingMessage paddingTop="10vh">Loading</LoadingMessage>
+              return <LoadingMessage paddingTop="10vh" />
             }
 
             return data.member.fileUploads.length === 0 ? (

--- a/src/components/member/tabs/FileTab.tsx
+++ b/src/components/member/tabs/FileTab.tsx
@@ -1,9 +1,13 @@
 import gql from 'graphql-tag'
+import {
+  MajorLoadingMessage,
+  MajorMessage,
+} from 'hedvig-ui/animations/major-message'
+import { dateTimeFormatter } from 'lib/helpers'
 import React from 'react'
 import { Query } from 'react-apollo'
 import { RouteComponentProps } from 'react-router'
 import { Image, Table } from 'semantic-ui-react'
-import { dateTimeFormatter } from '../../../lib/helpers'
 
 const query = gql`
   query FileUploadsQuery($memberId: ID!) {
@@ -85,11 +89,17 @@ class MemberFile extends React.Component<
             )
           }
           if (loading || !data) {
-            return <div>Loading...</div>
+            return (
+              <MajorLoadingMessage paddingTop="10vh">
+                Loading
+              </MajorLoadingMessage>
+            )
           }
 
           return data.member.fileUploads.length === 0 ? (
-            <div>No files uploaded for this member</div>
+            <MajorMessage paddingTop="10vh">
+              No files uploaded for this member
+            </MajorMessage>
           ) : (
             <MemberFileTable memberFiles={data.member.fileUploads} />
           )

--- a/src/components/member/tabs/FileTab.tsx
+++ b/src/components/member/tabs/FileTab.tsx
@@ -1,5 +1,5 @@
 import gql from 'graphql-tag'
-import { EaseIn } from 'hedvig-ui/animations/ease-in'
+import { FadeIn } from 'hedvig-ui/animations/fade-in'
 import {
   LoadingMessage,
   StandaloneMessage,
@@ -76,7 +76,7 @@ class MemberFile extends React.Component<
 > {
   public render() {
     return (
-      <EaseIn>
+      <FadeIn>
         <Query<any>
           query={query}
           variables={{ memberId: this.props.match.params.memberId }}
@@ -103,7 +103,7 @@ class MemberFile extends React.Component<
             )
           }}
         </Query>
-      </EaseIn>
+      </FadeIn>
     )
   }
 }

--- a/src/components/member/tabs/FileTab.tsx
+++ b/src/components/member/tabs/FileTab.tsx
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag'
+import { EaseIn } from 'hedvig-ui/animations/ease-in'
 import {
   MajorLoadingMessage,
   MajorMessage,
@@ -75,36 +76,38 @@ class MemberFile extends React.Component<
 > {
   public render() {
     return (
-      <Query<any>
-        query={query}
-        variables={{ memberId: this.props.match.params.memberId }}
-      >
-        {({ loading, error, data }) => {
-          if (error) {
-            return (
-              <div>
-                Error in GraphQl query here.....:{' '}
-                <pre>{JSON.stringify(error, null, 2)}</pre>
-              </div>
-            )
-          }
-          if (loading || !data) {
-            return (
-              <MajorLoadingMessage paddingTop="10vh">
-                Loading
-              </MajorLoadingMessage>
-            )
-          }
+      <EaseIn>
+        <Query<any>
+          query={query}
+          variables={{ memberId: this.props.match.params.memberId }}
+        >
+          {({ loading, error, data }) => {
+            if (error) {
+              return (
+                <div>
+                  Error in GraphQl query here.....:{' '}
+                  <pre>{JSON.stringify(error, null, 2)}</pre>
+                </div>
+              )
+            }
+            if (loading || !data) {
+              return (
+                <MajorLoadingMessage paddingTop="10vh">
+                  Loading
+                </MajorLoadingMessage>
+              )
+            }
 
-          return data.member.fileUploads.length === 0 ? (
-            <MajorMessage paddingTop="10vh">
-              No files uploaded for this member
-            </MajorMessage>
-          ) : (
-            <MemberFileTable memberFiles={data.member.fileUploads} />
-          )
-        }}
-      </Query>
+            return data.member.fileUploads.length === 0 ? (
+              <MajorMessage paddingTop="10vh">
+                No files uploaded for this member
+              </MajorMessage>
+            ) : (
+              <MemberFileTable memberFiles={data.member.fileUploads} />
+            )
+          }}
+        </Query>
+      </EaseIn>
     )
   }
 }

--- a/src/components/member/tabs/account-tab/index.tsx
+++ b/src/components/member/tabs/account-tab/index.tsx
@@ -37,7 +37,7 @@ export const AccountTab: React.FC<{
   const [account, { loading, refetch, error }] = useGetAccount(memberId)
 
   if (loading) {
-    return <LoadingMessage paddingTop="10vh">Loading</LoadingMessage>
+    return <LoadingMessage paddingTop="10vh" />
   }
   if (error || !account) {
     return (

--- a/src/components/member/tabs/account-tab/index.tsx
+++ b/src/components/member/tabs/account-tab/index.tsx
@@ -13,7 +13,7 @@ import {
 } from 'components/member/tabs/shared/card-components'
 import { Headline } from 'components/member/tabs/shared/headline'
 import { useGetAccount } from 'graphql/use-get-account'
-import { EaseIn } from 'hedvig-ui/animations/ease-in'
+import { FadeIn } from 'hedvig-ui/animations/fade-in'
 import {
   LoadingMessage,
   StandaloneMessage,
@@ -45,7 +45,7 @@ export const AccountTab: React.FC<{
     )
   }
   return (
-    <EaseIn>
+    <FadeIn>
       <Headline>
         Account
         <RefreshButton onClick={() => refetch()} loading={loading}>
@@ -130,6 +130,6 @@ export const AccountTab: React.FC<{
       </CardsWrapper>
       <AccountEntryTable accountEntries={account.entries} />
       <BackfillSubscriptionsButton memberId={memberId} />
-    </EaseIn>
+    </FadeIn>
   )
 }

--- a/src/components/member/tabs/account-tab/index.tsx
+++ b/src/components/member/tabs/account-tab/index.tsx
@@ -15,9 +15,9 @@ import { Headline } from 'components/member/tabs/shared/headline'
 import { useGetAccount } from 'graphql/use-get-account'
 import { EaseIn } from 'hedvig-ui/animations/ease-in'
 import {
-  MajorLoadingMessage,
-  MajorMessage,
-} from 'hedvig-ui/animations/major-message'
+  LoadingMessage,
+  StandaloneMessage,
+} from 'hedvig-ui/animations/standalone-message'
 import { Card, CardsWrapper } from 'hedvig-ui/card'
 import { Spacing } from 'hedvig-ui/spacing'
 import { Placeholder, ThirdLevelHeadline } from 'hedvig-ui/typography'
@@ -37,10 +37,12 @@ export const AccountTab: React.FC<{
   const [account, { loading, refetch, error }] = useGetAccount(memberId)
 
   if (loading) {
-    return <MajorLoadingMessage paddingTop="10vh">Loading</MajorLoadingMessage>
+    return <LoadingMessage paddingTop="10vh">Loading</LoadingMessage>
   }
   if (error || !account) {
-    return <MajorMessage paddingTop="10vh">No account found</MajorMessage>
+    return (
+      <StandaloneMessage paddingTop="10vh">No account found</StandaloneMessage>
+    )
   }
   return (
     <EaseIn>

--- a/src/components/member/tabs/account-tab/index.tsx
+++ b/src/components/member/tabs/account-tab/index.tsx
@@ -13,6 +13,10 @@ import {
 } from 'components/member/tabs/shared/card-components'
 import { Headline } from 'components/member/tabs/shared/headline'
 import { useGetAccount } from 'graphql/use-get-account'
+import {
+  MajorLoadingMessage,
+  MajorMessage,
+} from 'hedvig-ui/animations/major-message'
 import { Card, CardsWrapper } from 'hedvig-ui/card'
 import { Spacing } from 'hedvig-ui/spacing'
 import { Placeholder, ThirdLevelHeadline } from 'hedvig-ui/typography'
@@ -32,30 +36,10 @@ export const AccountTab: React.FC<{
   const [account, { loading, refetch, error }] = useGetAccount(memberId)
 
   if (loading) {
-    return (
-      <>
-        <Headline>
-          Account
-          <RefreshButton onClick={() => refetch()} loading={loading}>
-            <ArrowRepeat />
-          </RefreshButton>
-        </Headline>
-        Loading...
-      </>
-    )
+    return <MajorLoadingMessage paddingTop="10vh">Loading</MajorLoadingMessage>
   }
   if (error || !account) {
-    return (
-      <>
-        <Headline>
-          Account
-          <RefreshButton onClick={() => refetch()} loading={loading}>
-            <ArrowRepeat />
-          </RefreshButton>
-        </Headline>
-        No account found :(
-      </>
-    )
+    return <MajorMessage paddingTop="10vh">No account found</MajorMessage>
   }
   return (
     <>

--- a/src/components/member/tabs/account-tab/index.tsx
+++ b/src/components/member/tabs/account-tab/index.tsx
@@ -13,6 +13,7 @@ import {
 } from 'components/member/tabs/shared/card-components'
 import { Headline } from 'components/member/tabs/shared/headline'
 import { useGetAccount } from 'graphql/use-get-account'
+import { EaseIn } from 'hedvig-ui/animations/ease-in'
 import {
   MajorLoadingMessage,
   MajorMessage,
@@ -42,7 +43,7 @@ export const AccountTab: React.FC<{
     return <MajorMessage paddingTop="10vh">No account found</MajorMessage>
   }
   return (
-    <>
+    <EaseIn>
       <Headline>
         Account
         <RefreshButton onClick={() => refetch()} loading={loading}>
@@ -127,6 +128,6 @@ export const AccountTab: React.FC<{
       </CardsWrapper>
       <AccountEntryTable accountEntries={account.entries} />
       <BackfillSubscriptionsButton memberId={memberId} />
-    </>
+    </EaseIn>
   )
 }

--- a/src/components/member/tabs/campaigns-tab/index.tsx
+++ b/src/components/member/tabs/campaigns-tab/index.tsx
@@ -4,6 +4,7 @@ import { ReferralsInfo } from 'components/member/tabs/campaigns-tab/referrals/Re
 import { Headline } from 'components/member/tabs/shared/headline'
 import { RefreshButton } from 'components/member/tabs/shared/refresh-button'
 import { useGetReferralInformation } from 'graphql/use-get-referral-information'
+import { EaseIn } from 'hedvig-ui/animations/ease-in'
 import {
   MajorLoadingMessage,
   MajorMessage,
@@ -29,7 +30,7 @@ export const CampaignsTab: React.FunctionComponent<{
   }
 
   return (
-    <>
+    <EaseIn>
       <Headline>
         Campaigns
         <RefreshButton onClick={() => refetch()} loading={loading}>
@@ -47,6 +48,6 @@ export const CampaignsTab: React.FunctionComponent<{
         referralInformation={referralInformation}
         market={contractMarketInfo?.market}
       />
-    </>
+    </EaseIn>
   )
 }

--- a/src/components/member/tabs/campaigns-tab/index.tsx
+++ b/src/components/member/tabs/campaigns-tab/index.tsx
@@ -22,7 +22,7 @@ export const CampaignsTab: React.FunctionComponent<{
   ] = useGetReferralInformation(memberId)
 
   if (loading) {
-    return <LoadingMessage paddingTop="10vh">Loading</LoadingMessage>
+    return <LoadingMessage paddingTop="10vh" />
   }
 
   if (error || !referralInformation) {

--- a/src/components/member/tabs/campaigns-tab/index.tsx
+++ b/src/components/member/tabs/campaigns-tab/index.tsx
@@ -4,7 +4,7 @@ import { ReferralsInfo } from 'components/member/tabs/campaigns-tab/referrals/Re
 import { Headline } from 'components/member/tabs/shared/headline'
 import { RefreshButton } from 'components/member/tabs/shared/refresh-button'
 import { useGetReferralInformation } from 'graphql/use-get-referral-information'
-import { EaseIn } from 'hedvig-ui/animations/ease-in'
+import { FadeIn } from 'hedvig-ui/animations/fade-in'
 import {
   LoadingMessage,
   StandaloneMessage,
@@ -34,7 +34,7 @@ export const CampaignsTab: React.FunctionComponent<{
   }
 
   return (
-    <EaseIn>
+    <FadeIn>
       <Headline>
         Campaigns
         <RefreshButton onClick={() => refetch()} loading={loading}>
@@ -52,6 +52,6 @@ export const CampaignsTab: React.FunctionComponent<{
         referralInformation={referralInformation}
         market={contractMarketInfo?.market}
       />
-    </EaseIn>
+    </FadeIn>
   )
 }

--- a/src/components/member/tabs/campaigns-tab/index.tsx
+++ b/src/components/member/tabs/campaigns-tab/index.tsx
@@ -4,6 +4,10 @@ import { ReferralsInfo } from 'components/member/tabs/campaigns-tab/referrals/Re
 import { Headline } from 'components/member/tabs/shared/headline'
 import { RefreshButton } from 'components/member/tabs/shared/refresh-button'
 import { useGetReferralInformation } from 'graphql/use-get-referral-information'
+import {
+  MajorLoadingMessage,
+  MajorMessage,
+} from 'hedvig-ui/animations/major-message'
 import React from 'react'
 import { ArrowRepeat } from 'react-bootstrap-icons'
 
@@ -17,26 +21,11 @@ export const CampaignsTab: React.FunctionComponent<{
   ] = useGetReferralInformation(memberId)
 
   if (loading) {
-    return (
-      <>
-        <Headline>Campaigns</Headline>
-        Loading...
-      </>
-    )
+    return <MajorLoadingMessage paddingTop="10vh">Loading</MajorLoadingMessage>
   }
 
   if (error || !referralInformation) {
-    return (
-      <>
-        <Headline>
-          Campaigns
-          <RefreshButton onClick={() => refetch()} loading={loading}>
-            <ArrowRepeat />
-          </RefreshButton>
-        </Headline>
-        Something went wrong!
-      </>
-    )
+    return <MajorMessage paddingTop="10vh">Something went wrong</MajorMessage>
   }
 
   return (

--- a/src/components/member/tabs/campaigns-tab/index.tsx
+++ b/src/components/member/tabs/campaigns-tab/index.tsx
@@ -6,9 +6,9 @@ import { RefreshButton } from 'components/member/tabs/shared/refresh-button'
 import { useGetReferralInformation } from 'graphql/use-get-referral-information'
 import { EaseIn } from 'hedvig-ui/animations/ease-in'
 import {
-  MajorLoadingMessage,
-  MajorMessage,
-} from 'hedvig-ui/animations/major-message'
+  LoadingMessage,
+  StandaloneMessage,
+} from 'hedvig-ui/animations/standalone-message'
 import React from 'react'
 import { ArrowRepeat } from 'react-bootstrap-icons'
 
@@ -22,11 +22,15 @@ export const CampaignsTab: React.FunctionComponent<{
   ] = useGetReferralInformation(memberId)
 
   if (loading) {
-    return <MajorLoadingMessage paddingTop="10vh">Loading</MajorLoadingMessage>
+    return <LoadingMessage paddingTop="10vh">Loading</LoadingMessage>
   }
 
   if (error || !referralInformation) {
-    return <MajorMessage paddingTop="10vh">Something went wrong</MajorMessage>
+    return (
+      <StandaloneMessage paddingTop="10vh">
+        Something went wrong
+      </StandaloneMessage>
+    )
   }
 
   return (

--- a/src/components/member/tabs/contracts-tab/index.tsx
+++ b/src/components/member/tabs/contracts-tab/index.tsx
@@ -16,7 +16,7 @@ export const ContractTab: React.FunctionComponent<{
   const [contracts, { loading, refetch }] = useContracts(memberId)
 
   if (loading) {
-    return <LoadingMessage paddingTop="10vh">Loading</LoadingMessage>
+    return <LoadingMessage paddingTop="10vh" />
   }
 
   if (contracts.length === 0) {

--- a/src/components/member/tabs/contracts-tab/index.tsx
+++ b/src/components/member/tabs/contracts-tab/index.tsx
@@ -2,6 +2,10 @@ import { Contract } from 'components/member/tabs/contracts-tab/contract'
 import { Headline } from 'components/member/tabs/shared/headline'
 import { RefreshButton } from 'components/member/tabs/shared/refresh-button'
 import { useContracts } from 'graphql/use-contracts'
+import {
+  MajorLoadingMessage,
+  MajorMessage,
+} from 'hedvig-ui/animations/major-message'
 import React from 'react'
 import { ArrowRepeat } from 'react-bootstrap-icons'
 
@@ -9,6 +13,15 @@ export const ContractTab: React.FunctionComponent<{
   memberId: string
 }> = ({ memberId }) => {
   const [contracts, { loading, refetch }] = useContracts(memberId)
+
+  if (loading) {
+    return <MajorLoadingMessage paddingTop="10vh">Loading</MajorLoadingMessage>
+  }
+
+  if (contracts.length === 0) {
+    return <MajorMessage paddingTop="10vh">No contract for member</MajorMessage>
+  }
+
   return (
     <>
       <Headline>
@@ -17,8 +30,6 @@ export const ContractTab: React.FunctionComponent<{
           <ArrowRepeat />
         </RefreshButton>
       </Headline>
-      {loading && 'Loading...'}
-      {!loading && contracts.length === 0 && 'No contract for member'}
       {contracts.map((contract) => (
         <Contract
           key={contract.id}

--- a/src/components/member/tabs/contracts-tab/index.tsx
+++ b/src/components/member/tabs/contracts-tab/index.tsx
@@ -2,7 +2,7 @@ import { Contract } from 'components/member/tabs/contracts-tab/contract'
 import { Headline } from 'components/member/tabs/shared/headline'
 import { RefreshButton } from 'components/member/tabs/shared/refresh-button'
 import { useContracts } from 'graphql/use-contracts'
-import { EaseIn } from 'hedvig-ui/animations/ease-in'
+import { FadeIn } from 'hedvig-ui/animations/fade-in'
 import {
   LoadingMessage,
   StandaloneMessage,
@@ -28,7 +28,7 @@ export const ContractTab: React.FunctionComponent<{
   }
 
   return (
-    <EaseIn>
+    <FadeIn>
       <Headline>
         Contracts
         <RefreshButton onClick={() => refetch()} loading={loading}>
@@ -45,6 +45,6 @@ export const ContractTab: React.FunctionComponent<{
           }
         />
       ))}
-    </EaseIn>
+    </FadeIn>
   )
 }

--- a/src/components/member/tabs/contracts-tab/index.tsx
+++ b/src/components/member/tabs/contracts-tab/index.tsx
@@ -2,6 +2,7 @@ import { Contract } from 'components/member/tabs/contracts-tab/contract'
 import { Headline } from 'components/member/tabs/shared/headline'
 import { RefreshButton } from 'components/member/tabs/shared/refresh-button'
 import { useContracts } from 'graphql/use-contracts'
+import { EaseIn } from 'hedvig-ui/animations/ease-in'
 import {
   MajorLoadingMessage,
   MajorMessage,
@@ -23,7 +24,7 @@ export const ContractTab: React.FunctionComponent<{
   }
 
   return (
-    <>
+    <EaseIn>
       <Headline>
         Contracts
         <RefreshButton onClick={() => refetch()} loading={loading}>
@@ -40,6 +41,6 @@ export const ContractTab: React.FunctionComponent<{
           }
         />
       ))}
-    </>
+    </EaseIn>
   )
 }

--- a/src/components/member/tabs/contracts-tab/index.tsx
+++ b/src/components/member/tabs/contracts-tab/index.tsx
@@ -4,9 +4,9 @@ import { RefreshButton } from 'components/member/tabs/shared/refresh-button'
 import { useContracts } from 'graphql/use-contracts'
 import { EaseIn } from 'hedvig-ui/animations/ease-in'
 import {
-  MajorLoadingMessage,
-  MajorMessage,
-} from 'hedvig-ui/animations/major-message'
+  LoadingMessage,
+  StandaloneMessage,
+} from 'hedvig-ui/animations/standalone-message'
 import React from 'react'
 import { ArrowRepeat } from 'react-bootstrap-icons'
 
@@ -16,11 +16,15 @@ export const ContractTab: React.FunctionComponent<{
   const [contracts, { loading, refetch }] = useContracts(memberId)
 
   if (loading) {
-    return <MajorLoadingMessage paddingTop="10vh">Loading</MajorLoadingMessage>
+    return <LoadingMessage paddingTop="10vh">Loading</LoadingMessage>
   }
 
   if (contracts.length === 0) {
-    return <MajorMessage paddingTop="10vh">No contract for member</MajorMessage>
+    return (
+      <StandaloneMessage paddingTop="10vh">
+        No contract for member
+      </StandaloneMessage>
+    )
   }
 
   return (

--- a/src/components/member/tabs/debt-tab/index.tsx
+++ b/src/components/member/tabs/debt-tab/index.tsx
@@ -14,6 +14,7 @@ import {
 import { Headline } from 'components/member/tabs/shared/headline'
 import { RefreshButton } from 'components/member/tabs/shared/refresh-button'
 import { useGetPerson } from 'graphql/use-get-person'
+import { EaseIn } from 'hedvig-ui/animations/ease-in'
 import {
   MajorLoadingMessage,
   MajorMessage,
@@ -53,7 +54,7 @@ export const DebtTab: React.FC<{
   }
 
   return (
-    <>
+    <EaseIn>
       <Headline>
         Debt
         <RefreshButton onClick={() => refetch()} loading={loading}>
@@ -92,6 +93,6 @@ export const DebtTab: React.FC<{
           paymentDefaults={person.debt.paymentDefaults as PaymentDefault[]}
         />
       )}
-    </>
+    </EaseIn>
   )
 }

--- a/src/components/member/tabs/debt-tab/index.tsx
+++ b/src/components/member/tabs/debt-tab/index.tsx
@@ -14,6 +14,10 @@ import {
 import { Headline } from 'components/member/tabs/shared/headline'
 import { RefreshButton } from 'components/member/tabs/shared/refresh-button'
 import { useGetPerson } from 'graphql/use-get-person'
+import {
+  MajorLoadingMessage,
+  MajorMessage,
+} from 'hedvig-ui/animations/major-message'
 import { Card, CardsWrapper } from 'hedvig-ui/card'
 import { FlagOrbIndicator } from 'hedvig-ui/orb-indicator'
 import { Spacing } from 'hedvig-ui/spacing'
@@ -31,34 +35,20 @@ export const DebtTab: React.FC<{
 
   // FIXME: We should not make market specific features like this, should use "have debt" or "don't have debt" instead
   if (contractMarketInfo?.market === Market.Norway) {
-    return <>Not available for Norway</>
+    return (
+      <MajorMessage paddingTop="10vh">Not available for Norway</MajorMessage>
+    )
   }
 
   if (loading) {
-    return (
-      <>
-        <Headline>
-          Debt
-          <RefreshButton onClick={() => refetch()} loading={loading}>
-            <ArrowRepeat />
-          </RefreshButton>
-        </Headline>
-        Loading...
-      </>
-    )
+    return <MajorLoadingMessage paddingTop="10vh">Loading</MajorLoadingMessage>
   }
 
   if (error || !person) {
     return (
-      <>
-        <Headline>
-          Debt
-          <RefreshButton onClick={() => refetch()} loading={loading}>
-            <ArrowRepeat />
-          </RefreshButton>
-        </Headline>
+      <MajorMessage paddingTop="10vh">
         Issue retrieving debt for this member
-      </>
+      </MajorMessage>
     )
   }
 

--- a/src/components/member/tabs/debt-tab/index.tsx
+++ b/src/components/member/tabs/debt-tab/index.tsx
@@ -44,7 +44,7 @@ export const DebtTab: React.FC<{
   }
 
   if (loading) {
-    return <LoadingMessage paddingTop="10vh">Loading</LoadingMessage>
+    return <LoadingMessage paddingTop="10vh" />
   }
 
   if (error || !person) {

--- a/src/components/member/tabs/debt-tab/index.tsx
+++ b/src/components/member/tabs/debt-tab/index.tsx
@@ -16,9 +16,9 @@ import { RefreshButton } from 'components/member/tabs/shared/refresh-button'
 import { useGetPerson } from 'graphql/use-get-person'
 import { EaseIn } from 'hedvig-ui/animations/ease-in'
 import {
-  MajorLoadingMessage,
-  MajorMessage,
-} from 'hedvig-ui/animations/major-message'
+  LoadingMessage,
+  StandaloneMessage,
+} from 'hedvig-ui/animations/standalone-message'
 import { Card, CardsWrapper } from 'hedvig-ui/card'
 import { FlagOrbIndicator } from 'hedvig-ui/orb-indicator'
 import { Spacing } from 'hedvig-ui/spacing'
@@ -37,19 +37,21 @@ export const DebtTab: React.FC<{
   // FIXME: We should not make market specific features like this, should use "have debt" or "don't have debt" instead
   if (contractMarketInfo?.market === Market.Norway) {
     return (
-      <MajorMessage paddingTop="10vh">Not available for Norway</MajorMessage>
+      <StandaloneMessage paddingTop="10vh">
+        Not available for Norway
+      </StandaloneMessage>
     )
   }
 
   if (loading) {
-    return <MajorLoadingMessage paddingTop="10vh">Loading</MajorLoadingMessage>
+    return <LoadingMessage paddingTop="10vh">Loading</LoadingMessage>
   }
 
   if (error || !person) {
     return (
-      <MajorMessage paddingTop="10vh">
+      <StandaloneMessage paddingTop="10vh">
         Issue retrieving debt for this member
-      </MajorMessage>
+      </StandaloneMessage>
     )
   }
 

--- a/src/components/member/tabs/debt-tab/index.tsx
+++ b/src/components/member/tabs/debt-tab/index.tsx
@@ -14,7 +14,7 @@ import {
 import { Headline } from 'components/member/tabs/shared/headline'
 import { RefreshButton } from 'components/member/tabs/shared/refresh-button'
 import { useGetPerson } from 'graphql/use-get-person'
-import { EaseIn } from 'hedvig-ui/animations/ease-in'
+import { FadeIn } from 'hedvig-ui/animations/fade-in'
 import {
   LoadingMessage,
   StandaloneMessage,
@@ -56,7 +56,7 @@ export const DebtTab: React.FC<{
   }
 
   return (
-    <EaseIn>
+    <FadeIn>
       <Headline>
         Debt
         <RefreshButton onClick={() => refetch()} loading={loading}>
@@ -95,6 +95,6 @@ export const DebtTab: React.FC<{
           paymentDefaults={person.debt.paymentDefaults as PaymentDefault[]}
         />
       )}
-    </EaseIn>
+    </FadeIn>
   )
 }

--- a/src/components/member/tabs/index.tsx
+++ b/src/components/member/tabs/index.tsx
@@ -1,18 +1,17 @@
 import ClaimsTab from 'components/member/tabs/ClaimsTab'
+import { ContractTab } from 'components/member/tabs/contracts-tab'
 import { DetailsTab } from 'components/member/tabs/DetailsTab'
 import MemberFile from 'components/member/tabs/FileTab'
 import PaymentsTab from 'components/member/tabs/payments-tab'
 import { Quotes } from 'components/member/tabs/quote-tab'
-import { ContractTab } from 'components/member/tabs/contracts-tab'
 
-import PropTypes from 'prop-types'
-import React from 'react'
-import { Tab } from 'semantic-ui-react'
-import styled from 'react-emotion'
 import { useContractMarketInfo } from 'graphql/use-get-member-contract-market-info'
+import React from 'react'
+import styled from 'react-emotion'
+import { Tab } from 'semantic-ui-react'
 import { AccountTab } from './account-tab'
-import { DebtTab } from './debt-tab'
 import { CampaignsTab } from './campaigns-tab'
+import { DebtTab } from './debt-tab'
 
 const TabContainer = styled(Tab.Pane)`
   &&& {
@@ -23,7 +22,10 @@ const TabContainer = styled(Tab.Pane)`
   }
 `
 
-const TabItem = ({ props, TabContent }) => {
+const TabItem: React.FC<{ props: any; TabContent: any }> = ({
+  props,
+  TabContent,
+}) => {
   const memberId = props.match.params.memberId
   const [contractMarketInfo] = useContractMarketInfo(memberId)
   return (
@@ -31,13 +33,6 @@ const TabItem = ({ props, TabContent }) => {
       <TabContent {...props} contractMarketInfo={contractMarketInfo} />
     </TabContainer>
   )
-}
-
-TabItem.propTypes = {
-  props: PropTypes.object.isRequired,
-  TabContent: PropTypes.func,
-  isChatTab: PropTypes.bool,
-  hideTab: PropTypes.bool,
 }
 
 const memberPagePanes = (props, memberId, member) => [

--- a/src/components/member/tabs/payments-tab/index.js
+++ b/src/components/member/tabs/payments-tab/index.js
@@ -11,11 +11,11 @@ import { Button } from 'hedvig-ui/button'
 import { Market } from 'api/generated/graphql'
 import { formatMoney } from 'utils/money'
 import { GenerateSetupDirectDebitLink } from './generate-setup-direct-debit-link'
-import {
-  MajorLoadingMessage,
-  MajorMessage,
-} from 'hedvig-ui/animations/major-message'
 import { EaseIn } from 'hedvig-ui/animations/ease-in'
+import {
+  LoadingMessage,
+  StandaloneMessage,
+} from 'hedvig-ui/animations/standalone-message'
 
 const IconWrapper = styled.span`
   display: inline-block;
@@ -186,18 +186,14 @@ class PaymentsTab extends React.Component {
             if (error) {
               console.error(error)
               return (
-                <MajorMessage paddingTop="10vh">
+                <StandaloneMessage paddingTop="10vh">
                   Something went wrong
-                </MajorMessage>
+                </StandaloneMessage>
               )
             }
 
             if (loading || !data) {
-              return (
-                <MajorLoadingMessage paddingTop="10vh">
-                  Loading
-                </MajorLoadingMessage>
-              )
+              return <LoadingMessage paddingTop="10vh">Loading</LoadingMessage>
             }
 
             return (

--- a/src/components/member/tabs/payments-tab/index.js
+++ b/src/components/member/tabs/payments-tab/index.js
@@ -11,6 +11,10 @@ import { Button } from 'hedvig-ui/button'
 import { Market } from 'api/generated/graphql'
 import { formatMoney } from 'utils/money'
 import { GenerateSetupDirectDebitLink } from './generate-setup-direct-debit-link'
+import {
+  MajorLoadingMessage,
+  MajorMessage,
+} from 'hedvig-ui/animations/major-message'
 
 const IconWrapper = styled.span`
   display: inline-block;
@@ -179,11 +183,20 @@ class PaymentsTab extends React.Component {
         <Query query={GET_MEMBER_QUERY} variables={{ id: this.memberId }}>
           {({ loading, error, data }) => {
             if (error) {
-              return <div>{error.message}!</div>
+              console.error(error)
+              return (
+                <MajorMessage paddingTop="10vh">
+                  Something went wrong
+                </MajorMessage>
+              )
             }
 
             if (loading || !data) {
-              return <div>Loading...</div>
+              return (
+                <MajorLoadingMessage paddingTop="10vh">
+                  Loading
+                </MajorLoadingMessage>
+              )
             }
 
             return (

--- a/src/components/member/tabs/payments-tab/index.js
+++ b/src/components/member/tabs/payments-tab/index.js
@@ -15,6 +15,7 @@ import {
   MajorLoadingMessage,
   MajorMessage,
 } from 'hedvig-ui/animations/major-message'
+import { EaseIn } from 'hedvig-ui/animations/ease-in'
 
 const IconWrapper = styled.span`
   display: inline-block;
@@ -179,7 +180,7 @@ class PaymentsTab extends React.Component {
   // FIXME: Logic whether charge or payout can be performed should be owned by the backend
   render() {
     return (
-      <React.Fragment>
+      <EaseIn>
         <Query query={GET_MEMBER_QUERY} variables={{ id: this.memberId }}>
           {({ loading, error, data }) => {
             if (error) {
@@ -296,7 +297,7 @@ class PaymentsTab extends React.Component {
             )
           }}
         </Query>
-      </React.Fragment>
+      </EaseIn>
     )
   }
 }

--- a/src/components/member/tabs/payments-tab/index.js
+++ b/src/components/member/tabs/payments-tab/index.js
@@ -11,7 +11,7 @@ import { Button } from 'hedvig-ui/button'
 import { Market } from 'api/generated/graphql'
 import { formatMoney } from 'utils/money'
 import { GenerateSetupDirectDebitLink } from './generate-setup-direct-debit-link'
-import { EaseIn } from 'hedvig-ui/animations/ease-in'
+import { FadeIn } from 'hedvig-ui/animations/fade-in'
 import {
   LoadingMessage,
   StandaloneMessage,
@@ -180,7 +180,7 @@ class PaymentsTab extends React.Component {
   // FIXME: Logic whether charge or payout can be performed should be owned by the backend
   render() {
     return (
-      <EaseIn>
+      <FadeIn>
         <Query query={GET_MEMBER_QUERY} variables={{ id: this.memberId }}>
           {({ loading, error, data }) => {
             if (error) {
@@ -292,7 +292,7 @@ class PaymentsTab extends React.Component {
             )
           }}
         </Query>
-      </EaseIn>
+      </FadeIn>
     )
   }
 }

--- a/src/components/member/tabs/payments-tab/index.js
+++ b/src/components/member/tabs/payments-tab/index.js
@@ -184,7 +184,6 @@ class PaymentsTab extends React.Component {
         <Query query={GET_MEMBER_QUERY} variables={{ id: this.memberId }}>
           {({ loading, error, data }) => {
             if (error) {
-              console.error(error)
               return (
                 <StandaloneMessage paddingTop="10vh">
                   Something went wrong
@@ -193,7 +192,7 @@ class PaymentsTab extends React.Component {
             }
 
             if (loading || !data) {
-              return <LoadingMessage paddingTop="10vh">Loading</LoadingMessage>
+              return <LoadingMessage paddingTop="10vh" />
             }
 
             return (

--- a/src/components/member/tabs/quote-tab/index.tsx
+++ b/src/components/member/tabs/quote-tab/index.tsx
@@ -1,6 +1,10 @@
 import { Quote } from 'api/generated/graphql'
 import { useContractMarketInfo } from 'graphql/use-get-member-contract-market-info'
 import { useQuotes } from 'graphql/use-get-quotes'
+import {
+  MajorLoadingMessage,
+  MajorMessage,
+} from 'hedvig-ui/animations/major-message'
 import { getTextFromEnumValue } from 'hedvig-ui/dropdown'
 import * as React from 'react'
 import { Tab } from 'semantic-ui-react'
@@ -18,15 +22,19 @@ export const Quotes: React.FunctionComponent<{ memberId: string }> = ({
   const [contractMarket, { loading }] = useContractMarketInfo(memberId)
 
   if (loading || quotesLoading) {
-    return null
+    return <MajorLoadingMessage paddingTop="10vh">Loading</MajorLoadingMessage>
   }
 
   if (quotes.length === 0) {
-    return <em>No quotes :(</em>
+    return <MajorMessage paddingTop="10vh">No quotes</MajorMessage>
   }
 
   if (!contractMarket) {
-    return <>Unable to get Market, please contact Tech</>
+    return (
+      <MajorMessage paddingTop="10vh">
+        Unable to get Market, contact Tech
+      </MajorMessage>
+    )
   }
 
   const getUniqueContractTypes = () => {

--- a/src/components/member/tabs/quote-tab/index.tsx
+++ b/src/components/member/tabs/quote-tab/index.tsx
@@ -3,9 +3,9 @@ import { useContractMarketInfo } from 'graphql/use-get-member-contract-market-in
 import { useQuotes } from 'graphql/use-get-quotes'
 import { EaseIn } from 'hedvig-ui/animations/ease-in'
 import {
-  MajorLoadingMessage,
-  MajorMessage,
-} from 'hedvig-ui/animations/major-message'
+  LoadingMessage,
+  StandaloneMessage,
+} from 'hedvig-ui/animations/standalone-message'
 import { getTextFromEnumValue } from 'hedvig-ui/dropdown'
 import * as React from 'react'
 import { Tab } from 'semantic-ui-react'
@@ -23,18 +23,18 @@ export const Quotes: React.FunctionComponent<{ memberId: string }> = ({
   const [contractMarket, { loading }] = useContractMarketInfo(memberId)
 
   if (loading || quotesLoading) {
-    return <MajorLoadingMessage paddingTop="10vh">Loading</MajorLoadingMessage>
+    return <LoadingMessage paddingTop="10vh">Loading</LoadingMessage>
   }
 
   if (quotes.length === 0) {
-    return <MajorMessage paddingTop="10vh">No quotes</MajorMessage>
+    return <StandaloneMessage paddingTop="10vh">No quotes</StandaloneMessage>
   }
 
   if (!contractMarket) {
     return (
-      <MajorMessage paddingTop="10vh">
+      <StandaloneMessage paddingTop="10vh">
         Unable to get Market, contact Tech
-      </MajorMessage>
+      </StandaloneMessage>
     )
   }
 

--- a/src/components/member/tabs/quote-tab/index.tsx
+++ b/src/components/member/tabs/quote-tab/index.tsx
@@ -23,7 +23,7 @@ export const Quotes: React.FunctionComponent<{ memberId: string }> = ({
   const [contractMarket, { loading }] = useContractMarketInfo(memberId)
 
   if (loading || quotesLoading) {
-    return <LoadingMessage paddingTop="10vh">Loading</LoadingMessage>
+    return <LoadingMessage paddingTop="10vh" />
   }
 
   if (quotes.length === 0) {

--- a/src/components/member/tabs/quote-tab/index.tsx
+++ b/src/components/member/tabs/quote-tab/index.tsx
@@ -1,6 +1,7 @@
 import { Quote } from 'api/generated/graphql'
 import { useContractMarketInfo } from 'graphql/use-get-member-contract-market-info'
 import { useQuotes } from 'graphql/use-get-quotes'
+import { EaseIn } from 'hedvig-ui/animations/ease-in'
 import {
   MajorLoadingMessage,
   MajorMessage,
@@ -81,11 +82,13 @@ export const Quotes: React.FunctionComponent<{ memberId: string }> = ({
       menuItem: getTextFromEnumValue(contractType),
       render: () => (
         <Tab.Pane>
-          <QuotesSubSection
-            memberId={memberId}
-            contractType={contractType}
-            quotes={getCategorisedQuotesBasedOnContractType(contractType)}
-          />
+          <EaseIn>
+            <QuotesSubSection
+              memberId={memberId}
+              contractType={contractType}
+              quotes={getCategorisedQuotesBasedOnContractType(contractType)}
+            />
+          </EaseIn>
         </Tab.Pane>
       ),
     }))

--- a/src/components/member/tabs/quote-tab/index.tsx
+++ b/src/components/member/tabs/quote-tab/index.tsx
@@ -1,7 +1,7 @@
 import { Quote } from 'api/generated/graphql'
 import { useContractMarketInfo } from 'graphql/use-get-member-contract-market-info'
 import { useQuotes } from 'graphql/use-get-quotes'
-import { EaseIn } from 'hedvig-ui/animations/ease-in'
+import { FadeIn } from 'hedvig-ui/animations/fade-in'
 import {
   LoadingMessage,
   StandaloneMessage,
@@ -82,13 +82,13 @@ export const Quotes: React.FunctionComponent<{ memberId: string }> = ({
       menuItem: getTextFromEnumValue(contractType),
       render: () => (
         <Tab.Pane>
-          <EaseIn>
+          <FadeIn>
             <QuotesSubSection
               memberId={memberId}
               contractType={contractType}
               quotes={getCategorisedQuotesBasedOnContractType(contractType)}
             />
-          </EaseIn>
+          </FadeIn>
         </Tab.Pane>
       ),
     }))

--- a/src/components/members-search/index.tsx
+++ b/src/components/members-search/index.tsx
@@ -11,7 +11,7 @@ import {
 } from 'components/members-search/styles'
 import BackendPaginatorList from 'components/shared/paginator-list/BackendPaginatorList'
 import { useMemberSearch } from 'graphql/use-member-search'
-import { EaseIn } from 'hedvig-ui/animations/ease-in'
+import { FadeIn } from 'hedvig-ui/animations/fade-in'
 import { MainHeadline } from 'hedvig-ui/typography'
 import React, { useRef } from 'react'
 import { findDOMNode } from 'react-dom'
@@ -97,7 +97,7 @@ export const MembersSearch: React.FC = () => {
       />
       {members.length > 0 && (
         <ListWrapper>
-          <EaseIn>
+          <FadeIn>
             <BackendPaginatorList<Member>
               currentPage={page}
               totalPages={totalPages}
@@ -118,7 +118,7 @@ export const MembersSearch: React.FC = () => {
               isSortable={false}
               tableHeader={<ListHeader />}
             />
-          </EaseIn>
+          </FadeIn>
         </ListWrapper>
       )}
       {members.length === 0 && !query && (

--- a/src/components/members-search/index.tsx
+++ b/src/components/members-search/index.tsx
@@ -11,6 +11,7 @@ import {
 } from 'components/members-search/styles'
 import BackendPaginatorList from 'components/shared/paginator-list/BackendPaginatorList'
 import { useMemberSearch } from 'graphql/use-member-search'
+import { EaseIn } from 'hedvig-ui/animations/ease-in'
 import { MainHeadline } from 'hedvig-ui/typography'
 import React, { useRef } from 'react'
 import { findDOMNode } from 'react-dom'
@@ -96,22 +97,28 @@ export const MembersSearch: React.FC = () => {
       />
       {members.length > 0 && (
         <ListWrapper>
-          <BackendPaginatorList<Member>
-            currentPage={page}
-            totalPages={totalPages}
-            changePage={(nextPage) =>
-              memberSearch(query, { includeAll, page: nextPage, pageSize: 25 })
-            }
-            pagedItems={members}
-            itemContent={(member, index) => (
-              <ListItem
-                member={member}
-                active={currentKeyboardNavigationStep === index}
-              />
-            )}
-            isSortable={false}
-            tableHeader={<ListHeader />}
-          />
+          <EaseIn>
+            <BackendPaginatorList<Member>
+              currentPage={page}
+              totalPages={totalPages}
+              changePage={(nextPage) =>
+                memberSearch(query, {
+                  includeAll,
+                  page: nextPage,
+                  pageSize: 25,
+                })
+              }
+              pagedItems={members}
+              itemContent={(member, index) => (
+                <ListItem
+                  member={member}
+                  active={currentKeyboardNavigationStep === index}
+                />
+              )}
+              isSortable={false}
+              tableHeader={<ListHeader />}
+            />
+          </EaseIn>
         </ListWrapper>
       )}
       {members.length === 0 && !query && (

--- a/src/components/questions/index.tsx
+++ b/src/components/questions/index.tsx
@@ -1,5 +1,6 @@
 import QuestionGroups from 'components/questions/questions-list/QuestionGroups'
 import { useQuestionGroups } from 'graphql/use-question-groups'
+import { MajorLoadingMessage } from 'hedvig-ui/animations/major-message'
 import { Spacing } from 'hedvig-ui/spacing'
 import * as React from 'react'
 import { useInsecurePersistentState } from 'utils/state'
@@ -20,7 +21,7 @@ const Questions: React.FC = () => {
   const [questionGroups, { loading }] = useQuestionGroups()
 
   if (loading) {
-    return <>Loading...</>
+    return <MajorLoadingMessage>Loading</MajorLoadingMessage>
   }
 
   if (!questionGroups) {

--- a/src/components/questions/index.tsx
+++ b/src/components/questions/index.tsx
@@ -1,6 +1,9 @@
 import QuestionGroups from 'components/questions/questions-list/QuestionGroups'
 import { useQuestionGroups } from 'graphql/use-question-groups'
-import { MajorLoadingMessage } from 'hedvig-ui/animations/major-message'
+import {
+  MajorLoadingMessage,
+  MajorMessage,
+} from 'hedvig-ui/animations/major-message'
 import { Spacing } from 'hedvig-ui/spacing'
 import * as React from 'react'
 import { useInsecurePersistentState } from 'utils/state'
@@ -25,7 +28,7 @@ const Questions: React.FC = () => {
   }
 
   if (!questionGroups) {
-    return <>Something went wrong :(</>
+    return <MajorMessage>Something went wrong!</MajorMessage>
   }
 
   return (

--- a/src/components/questions/index.tsx
+++ b/src/components/questions/index.tsx
@@ -1,5 +1,6 @@
 import QuestionGroups from 'components/questions/questions-list/QuestionGroups'
 import { useQuestionGroups } from 'graphql/use-question-groups'
+import { EaseIn } from 'hedvig-ui/animations/ease-in'
 import {
   MajorLoadingMessage,
   MajorMessage,
@@ -34,19 +35,21 @@ const Questions: React.FC = () => {
   return (
     <>
       <Spacing bottom="large">
-        <QuestionsFilter
-          questionGroups={questionGroups}
-          selected={selectedFilters}
-          onToggle={(newFilter) => {
-            if (selectedFilters.includes(newFilter)) {
-              setSelectedFilters(
-                selectedFilters.filter((filter) => filter !== newFilter),
-              )
-            } else {
-              setSelectedFilters([...selectedFilters, newFilter])
-            }
-          }}
-        />
+        <EaseIn>
+          <QuestionsFilter
+            questionGroups={questionGroups}
+            selected={selectedFilters}
+            onToggle={(newFilter) => {
+              if (selectedFilters.includes(newFilter)) {
+                setSelectedFilters(
+                  selectedFilters.filter((filter) => filter !== newFilter),
+                )
+              } else {
+                setSelectedFilters([...selectedFilters, newFilter])
+              }
+            }}
+          />
+        </EaseIn>
       </Spacing>
 
       <QuestionGroups

--- a/src/components/questions/index.tsx
+++ b/src/components/questions/index.tsx
@@ -1,6 +1,6 @@
 import QuestionGroups from 'components/questions/questions-list/QuestionGroups'
 import { useQuestionGroups } from 'graphql/use-question-groups'
-import { EaseIn } from 'hedvig-ui/animations/ease-in'
+import { FadeIn } from 'hedvig-ui/animations/fade-in'
 import {
   LoadingMessage,
   StandaloneMessage,
@@ -39,7 +39,7 @@ const Questions: React.FC = () => {
   return (
     <>
       <Spacing bottom="large">
-        <EaseIn>
+        <FadeIn>
           <QuestionsFilter
             questionGroups={questionGroups}
             selected={selectedFilters}
@@ -53,7 +53,7 @@ const Questions: React.FC = () => {
               }
             }}
           />
-        </EaseIn>
+        </FadeIn>
       </Spacing>
 
       <QuestionGroups

--- a/src/components/questions/index.tsx
+++ b/src/components/questions/index.tsx
@@ -25,11 +25,15 @@ const Questions: React.FC = () => {
   const [questionGroups, { loading }] = useQuestionGroups()
 
   if (loading) {
-    return <LoadingMessage>Loading</LoadingMessage>
+    return <LoadingMessage paddingTop={'25vh'} />
   }
 
   if (!questionGroups) {
-    return <StandaloneMessage>Something went wrong!</StandaloneMessage>
+    return (
+      <StandaloneMessage paddingTop="25vh">
+        Something went wrong!
+      </StandaloneMessage>
+    )
   }
 
   return (

--- a/src/components/questions/index.tsx
+++ b/src/components/questions/index.tsx
@@ -2,9 +2,9 @@ import QuestionGroups from 'components/questions/questions-list/QuestionGroups'
 import { useQuestionGroups } from 'graphql/use-question-groups'
 import { EaseIn } from 'hedvig-ui/animations/ease-in'
 import {
-  MajorLoadingMessage,
-  MajorMessage,
-} from 'hedvig-ui/animations/major-message'
+  LoadingMessage,
+  StandaloneMessage,
+} from 'hedvig-ui/animations/standalone-message'
 import { Spacing } from 'hedvig-ui/spacing'
 import * as React from 'react'
 import { useInsecurePersistentState } from 'utils/state'
@@ -25,11 +25,11 @@ const Questions: React.FC = () => {
   const [questionGroups, { loading }] = useQuestionGroups()
 
   if (loading) {
-    return <MajorLoadingMessage>Loading</MajorLoadingMessage>
+    return <LoadingMessage>Loading</LoadingMessage>
   }
 
   if (!questionGroups) {
-    return <MajorMessage>Something went wrong!</MajorMessage>
+    return <StandaloneMessage>Something went wrong!</StandaloneMessage>
   }
 
   return (

--- a/src/components/questions/questions-list/FilteredQuestionGroups.js
+++ b/src/components/questions/questions-list/FilteredQuestionGroups.js
@@ -3,6 +3,7 @@ import React from 'react'
 import { Header, Segment } from 'semantic-ui-react'
 import styled from 'react-emotion'
 import { QuestionGroup } from './QuestionGroup'
+import { EaseIn } from 'hedvig-ui/animations/ease-in'
 
 const List = styled(Segment)`
   width: 100%;
@@ -18,11 +19,13 @@ export const FilteredQuestionGroups = ({ filterQuestionGroups }) => {
     <List>
       {filterQuestionGroups.length ? (
         <>
-          {filterQuestionGroups.map((questionGroup) => (
-            <QuestionGroup
-              key={questionGroup.id}
-              questionGroup={questionGroup}
-            />
+          {filterQuestionGroups.map((questionGroup, index) => (
+            <EaseIn delay={`${index*100}ms`}>
+              <QuestionGroup
+                key={questionGroup.id}
+                questionGroup={questionGroup}
+              />
+            </EaseIn>
           ))}
         </>
       ) : (

--- a/src/components/questions/questions-list/FilteredQuestionGroups.js
+++ b/src/components/questions/questions-list/FilteredQuestionGroups.js
@@ -3,7 +3,7 @@ import React from 'react'
 import { Segment } from 'semantic-ui-react'
 import styled from 'react-emotion'
 import { QuestionGroup } from './QuestionGroup'
-import { EaseIn } from 'hedvig-ui/animations/ease-in'
+import { FadeIn } from 'hedvig-ui/animations/fade-in'
 import { StandaloneMessage } from 'hedvig-ui/animations/standalone-message'
 
 const List = styled(Segment)`
@@ -21,12 +21,12 @@ export const FilteredQuestionGroups = ({ filterQuestionGroups }) => {
       {filterQuestionGroups.length ? (
         <>
           {filterQuestionGroups.map((questionGroup, index) => (
-            <EaseIn delay={`${index * 100}ms`}>
+            <FadeIn delay={`${index * 100}ms`}>
               <QuestionGroup
                 key={questionGroup.id}
                 questionGroup={questionGroup}
               />
-            </EaseIn>
+            </FadeIn>
           ))}
         </>
       ) : (

--- a/src/components/questions/questions-list/FilteredQuestionGroups.js
+++ b/src/components/questions/questions-list/FilteredQuestionGroups.js
@@ -1,9 +1,10 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { Header, Segment } from 'semantic-ui-react'
+import { Segment } from 'semantic-ui-react'
 import styled from 'react-emotion'
 import { QuestionGroup } from './QuestionGroup'
 import { EaseIn } from 'hedvig-ui/animations/ease-in'
+import { StandaloneMessage } from 'hedvig-ui/animations/standalone-message'
 
 const List = styled(Segment)`
   width: 100%;
@@ -20,7 +21,7 @@ export const FilteredQuestionGroups = ({ filterQuestionGroups }) => {
       {filterQuestionGroups.length ? (
         <>
           {filterQuestionGroups.map((questionGroup, index) => (
-            <EaseIn delay={`${index*100}ms`}>
+            <EaseIn delay={`${index * 100}ms`}>
               <QuestionGroup
                 key={questionGroup.id}
                 questionGroup={questionGroup}
@@ -29,7 +30,7 @@ export const FilteredQuestionGroups = ({ filterQuestionGroups }) => {
           ))}
         </>
       ) : (
-        <Header>List is empty</Header>
+        <StandaloneMessage paddingTop="25vh">List is empty</StandaloneMessage>
       )}
     </List>
   )

--- a/src/features/tools/charges/index.tsx
+++ b/src/features/tools/charges/index.tsx
@@ -2,7 +2,7 @@ import { colors } from '@hedviginsurance/brand'
 import { format } from 'date-fns'
 import gql from 'graphql-tag'
 import { EaseIn } from 'hedvig-ui/animations/ease-in'
-import { MajorLoadingMessage } from 'hedvig-ui/animations/major-message'
+import { StandaloneMessage } from 'hedvig-ui/animations/standalone-message'
 import { MainHeadline } from 'hedvig-ui/typography'
 import { MonetaryAmount } from 'lib/helpers'
 import React from 'react'
@@ -167,7 +167,7 @@ export class ChargePageComponent extends React.Component<
               )
             }
             if (loading || !data || !data.paymentSchedule) {
-              return <MajorLoadingMessage>Loading</MajorLoadingMessage>
+              return <StandaloneMessage>Loading</StandaloneMessage>
             }
             return (
               <EaseIn>

--- a/src/features/tools/charges/index.tsx
+++ b/src/features/tools/charges/index.tsx
@@ -2,7 +2,7 @@ import { colors } from '@hedviginsurance/brand'
 import { format } from 'date-fns'
 import gql from 'graphql-tag'
 import { EaseIn } from 'hedvig-ui/animations/ease-in'
-import { StandaloneMessage } from 'hedvig-ui/animations/standalone-message'
+import { LoadingMessage } from 'hedvig-ui/animations/standalone-message'
 import { MainHeadline } from 'hedvig-ui/typography'
 import { MonetaryAmount } from 'lib/helpers'
 import React from 'react'
@@ -167,7 +167,7 @@ export class ChargePageComponent extends React.Component<
               )
             }
             if (loading || !data || !data.paymentSchedule) {
-              return <StandaloneMessage>Loading</StandaloneMessage>
+              return <LoadingMessage paddingTop="10vh" />
             }
             return (
               <EaseIn>

--- a/src/features/tools/charges/index.tsx
+++ b/src/features/tools/charges/index.tsx
@@ -1,6 +1,8 @@
 import { colors } from '@hedviginsurance/brand'
 import { format } from 'date-fns'
 import gql from 'graphql-tag'
+import { EaseIn } from 'hedvig-ui/animations/ease-in'
+import { MajorLoadingMessage } from 'hedvig-ui/animations/major-message'
 import { MainHeadline } from 'hedvig-ui/typography'
 import { MonetaryAmount } from 'lib/helpers'
 import React from 'react'
@@ -165,10 +167,10 @@ export class ChargePageComponent extends React.Component<
               )
             }
             if (loading || !data || !data.paymentSchedule) {
-              return <div>Loading...</div>
+              return <MajorLoadingMessage>Loading</MajorLoadingMessage>
             }
             return (
-              <>
+              <EaseIn>
                 <MainHeadline>💰 Approve charges</MainHeadline>
                 <Table celled>
                   <Table.Header>
@@ -244,7 +246,7 @@ export class ChargePageComponent extends React.Component<
                     <ConfirmMessage>Are you sure?</ConfirmMessage>
                   ) : null}
                 </ButtonWrapper>
-              </>
+              </EaseIn>
             )
           }}
         </Query>

--- a/src/features/tools/charges/index.tsx
+++ b/src/features/tools/charges/index.tsx
@@ -1,7 +1,7 @@
 import { colors } from '@hedviginsurance/brand'
 import { format } from 'date-fns'
 import gql from 'graphql-tag'
-import { EaseIn } from 'hedvig-ui/animations/ease-in'
+import { FadeIn } from 'hedvig-ui/animations/fade-in'
 import { LoadingMessage } from 'hedvig-ui/animations/standalone-message'
 import { MainHeadline } from 'hedvig-ui/typography'
 import { MonetaryAmount } from 'lib/helpers'
@@ -170,7 +170,7 @@ export class ChargePageComponent extends React.Component<
               return <LoadingMessage paddingTop="10vh" />
             }
             return (
-              <EaseIn>
+              <FadeIn>
                 <MainHeadline>💰 Approve charges</MainHeadline>
                 <Table celled>
                   <Table.Header>
@@ -246,7 +246,7 @@ export class ChargePageComponent extends React.Component<
                     <ConfirmMessage>Are you sure?</ConfirmMessage>
                   ) : null}
                 </ButtonWrapper>
-              </EaseIn>
+              </FadeIn>
             )
           }}
         </Query>

--- a/src/features/tools/index.tsx
+++ b/src/features/tools/index.tsx
@@ -2,6 +2,7 @@ import {
   StagingTools,
   stagingToolsAvailable,
 } from 'features/tools/staging-tools'
+import { EaseIn } from 'hedvig-ui/animations/ease-in'
 import { Card, CardsWrapper } from 'hedvig-ui/card'
 import React from 'react'
 import styled from 'react-emotion'
@@ -15,7 +16,7 @@ const Icon = styled('div')`
 export const CardLink = Card.withComponent(Link)
 
 export const Tools: React.FC = () => (
-  <>
+  <EaseIn>
     <CardsWrapper>
       <CardLink to="/tools/charges" span={4}>
         <Icon>💰</Icon>
@@ -49,5 +50,5 @@ export const Tools: React.FC = () => (
     </CardsWrapper>
 
     {stagingToolsAvailable() && <StagingTools />}
-  </>
+  </EaseIn>
 )

--- a/src/features/tools/index.tsx
+++ b/src/features/tools/index.tsx
@@ -2,7 +2,7 @@ import {
   StagingTools,
   stagingToolsAvailable,
 } from 'features/tools/staging-tools'
-import { EaseIn } from 'hedvig-ui/animations/ease-in'
+import { FadeIn } from 'hedvig-ui/animations/fade-in'
 import { Card, CardsWrapper } from 'hedvig-ui/card'
 import React from 'react'
 import styled from 'react-emotion'
@@ -16,7 +16,7 @@ const Icon = styled('div')`
 export const CardLink = Card.withComponent(Link)
 
 export const Tools: React.FC = () => (
-  <EaseIn>
+  <FadeIn>
     <CardsWrapper>
       <CardLink to="/tools/charges" span={4}>
         <Icon>💰</Icon>
@@ -50,5 +50,5 @@ export const Tools: React.FC = () => (
     </CardsWrapper>
 
     {stagingToolsAvailable() && <StagingTools />}
-  </EaseIn>
+  </FadeIn>
 )

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -1,3 +1,4 @@
+import { MajorLoadingMessage } from 'hedvig-ui/animations/major-message'
 import React from 'react'
 import { connect } from 'react-redux'
 import { Redirect, Route } from 'react-router'
@@ -21,7 +22,7 @@ const PrivateRouteComponent = ({
       {...rest}
       render={(props) => {
         if (authState === AuthState.UNKNOWN) {
-          return 'loading'
+          return <MajorLoadingMessage>Loading</MajorLoadingMessage>
         }
 
         if (authState === AuthState.UNAUTHENTICATED) {

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -1,4 +1,4 @@
-import { MajorLoadingMessage } from 'hedvig-ui/animations/major-message'
+import { LoadingMessage } from 'hedvig-ui/animations/standalone-message'
 import React from 'react'
 import { connect } from 'react-redux'
 import { Redirect, Route } from 'react-router'
@@ -22,7 +22,7 @@ const PrivateRouteComponent = ({
       {...rest}
       render={(props) => {
         if (authState === AuthState.UNKNOWN) {
-          return <MajorLoadingMessage>Loading</MajorLoadingMessage>
+          return <LoadingMessage>Loading</LoadingMessage>
         }
 
         if (authState === AuthState.UNAUTHENTICATED) {

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -22,7 +22,9 @@ const PrivateRouteComponent = ({
       {...rest}
       render={(props) => {
         if (authState === AuthState.UNKNOWN) {
-          return <LoadingMessage>Loading</LoadingMessage>
+          return (
+            <LoadingMessage paddingTop={'25vh'}>Authenticating</LoadingMessage>
+          )
         }
 
         if (authState === AuthState.UNAUTHENTICATED) {


### PR DESCRIPTION
## What's up 💅

### Loading and Error feedback
If you navigate H.ope for a couple of minutes, you will notice that every change of screen, query and mutation handles loading and error feedback differently. For example, you will find awkward messages saying: "Loading", "Loading...", "loading", "Something went wrong" etc., often as an unformatted string. This is without doubt convenient, but it's not pretty nor remarkable. To handle this, with inspiration from @palmenhq's lovely member search animations, we now have `MajorMessage` and `MajorLoadingMessage` (simply a `MajorMessage` with animated ellipsis at the end). 

Let's just not do `if (loading) { return <div>Loading...</div> }` anymore. 
Do `if (loading) { return <MajorLoadingMessage>Loading</MajorLoadingMessage> }`

##### Example 

![1](https://user-images.githubusercontent.com/51323202/96578299-403cea00-12d5-11eb-8198-1ef840209518.gif)

### Smooth transitions between screens
On the same note, we have a lot of different screens / routes where content should be updated once data has been retrieved. Currently, the data pops up whenever it's available, but I feel we could do better (and as already mentioned, why not strive for the same 'wow'-feeling you get at `/dashborad` and `/members` 🌟). With that said, animations could escalate. So I kept it simple and introduced a wrapper component, `EaseIn`, to simply get smooth transitions for whatever you want. 

##### Example

![2](https://user-images.githubusercontent.com/51323202/96579772-b0e50600-12d7-11eb-82a5-31bb513c0683.gif)

![3](https://user-images.githubusercontent.com/51323202/96579792-b3476000-12d7-11eb-9c6e-b7e20e4cdabd.gif)

##### Disclaimer
Honestly don't know if these animations would hurt performance or if I'm missing something obvious. Just a suggestion, I think it looks pretty neat, but perhaps it is _too much_ if we have it everywhere 🤓 @palmenhq 

##### To do before merge ✅
- Add Storyblok examples
