### PR TITLE
Fix claims list issues, decrease dashboard polling interval

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,0 @@
-[ ] `src/changelog.ts` updated

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -9,7 +9,8 @@
 ## Optional screenshots
 
 ## Optional checklist
-- [ ] Boyscouted
+- [ ] Updated `src/changelog.ts`
+- [ ] Codescouted
 - [ ] Unit tests written
-- [ ] Tested locally
+- [ ] Tested locally
 

--- a/shared/hedvig-ui/date-time-picker.tsx
+++ b/shared/hedvig-ui/date-time-picker.tsx
@@ -19,18 +19,17 @@ interface DatePickerProps {
   name?: string
 }
 
-const StyledInput = styled(Input)<{ fullWidth?: boolean }>(
-  ({ fullWidth = false }) => {
-    return {
-      '&&': {
-        width: fullWidth ? '100%' : '150px',
-      },
-      '&& input:hover': {
-        cursor: 'pointer !important',
-      },
-    }
-  },
-)
+const StyledInput = styled(Input)<{ fullWidth?: boolean }>`
+  && {
+    width: ${({ fullWidth }) => (fullWidth ? '100%' : '150px')};
+  }
+  && input:hover {
+    cursor: pointer !important;
+  }
+  && input {
+    caret-color: transparent;
+  }
+`
 
 export const DateTimePicker: React.FunctionComponent<DatePickerProps> = ({
   date,
@@ -66,7 +65,8 @@ export const DateTimePicker: React.FunctionComponent<DatePickerProps> = ({
           maxLength={10}
         />
       }
-      dateFormat={'yyyy-MM-dd'}
+      dateFormat={showTimePicker ? 'yyyy-MM-dd HH:mm' : 'yyyy-MM-dd'}
+      timeIntervals={1}
     />
   )
 }

--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ import { Provider } from 'react-redux'
 import { Redirect, Route, Router, Switch } from 'react-router'
 import Routes from 'routes'
 import Store, { history } from 'store'
-import { DarkmodeContext, getDefaultIsDarkmode } from './utils/darkmode-context'
+import { DarkmodeContext, getDefaultIsDarkmode } from 'utils/darkmode-context'
 import {
   darkTheme,
   darkUiTheme,
@@ -21,7 +21,7 @@ import {
   lightUiTheme,
   SemanticOverrides,
 } from 'hedvig-ui/themes'
-import { MemberHistoryProvider } from './utils/member-history'
+import { MemberHistoryProvider } from 'utils/member-history'
 
 const store = Store.configureStore()
 

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -12,8 +12,13 @@ export interface Change {
 
 export const changelog: ReadonlyArray<Change> = [
   {
+    date: '2021-01-26',
+    change: 'Claims list fixes, decrease Dashborad polling interval',
+    authorGithubHandle: 'vonElfvin',
+  },
+  {
     date: '2021-01-25',
-    change: 'Add payout status to payments',
+    change: 'Add payout support for Norway',
     authorGithubHandle: 'bystam',
   },
   {

--- a/src/components/claims/claim-details/components/ClaimEvents.tsx
+++ b/src/components/claims/claim-details/components/ClaimEvents.tsx
@@ -26,7 +26,7 @@ export const ClaimEvents: React.SFC<Props> = ({ events }) => (
     <MuiList>
       {events.filter(Boolean).map((event) => (
         <ListItem key={event!.date}>
-          {format(parseISO(event!.date), 'yyyy-MM-dd hh:mm:ss')}: {event!.text}
+          {format(parseISO(event!.date), 'yyyy-MM-dd HH:mm:ss')}: {event!.text}
         </ListItem>
       ))}
     </MuiList>

--- a/src/components/claims/claim-details/components/ClaimInformation.tsx
+++ b/src/components/claims/claim-details/components/ClaimInformation.tsx
@@ -58,8 +58,6 @@ const getUrlWithoutParameters = (recordingUrl): string => {
   return regex[0]
 }
 
-const AudioWrapper = styled('div')({})
-
 const Audio = styled('audio')({
   width: '100%',
 })
@@ -87,41 +85,42 @@ const ClaimInformation: React.FC<Props> = ({
   const [setContractForClaim] = useSetContractForClaim()
   const [setCoveringEmployee] = useSetCoveringEmployee()
   const [updateClaimState] = useUpdateClaimState()
-
   return (
     <Paper>
       <h3>Claim Information</h3>
-      {recordingUrl && (
-        <AudioWrapper>
-          <p>
-            Registered at:{' '}
-            {format(parseISO(registrationDate), 'yyyy-MM-dd hh:mm:ss')}
-          </p>
-          <Audio controls>
-            <source src={recordingUrl} type="audio/aac" />
-          </Audio>
-          <Audio controls>
-            <source
-              src={getUrlWithoutParameters(recordingUrl)}
-              type="audio/aac"
-            />
-          </Audio>
-          <DownloadClaimFile
-            href={recordingUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Download claim file
-          </DownloadClaimFile>
-          <DownloadClaimFile
-            href={getUrlWithoutParameters(recordingUrl)}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Download claim file
-          </DownloadClaimFile>
-        </AudioWrapper>
-      )}
+      <div>
+        <p>
+          Registered at:{' '}
+          {format(parseISO(registrationDate), 'yyyy-MM-dd HH:mm:ss')}
+        </p>
+        {recordingUrl && (
+          <>
+            <Audio controls>
+              <source src={recordingUrl} type="audio/aac" />
+            </Audio>
+            <Audio controls>
+              <source
+                src={getUrlWithoutParameters(recordingUrl)}
+                type="audio/aac"
+              />
+            </Audio>
+            <DownloadClaimFile
+              href={recordingUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Download claim file
+            </DownloadClaimFile>
+            <DownloadClaimFile
+              href={getUrlWithoutParameters(recordingUrl)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Download claim file
+            </DownloadClaimFile>
+          </>
+        )}
+      </div>
       <SelectWrapper>
         <MuiInputLabel shrink>Status</MuiInputLabel>
         <MuiSelect

--- a/src/components/claims/claim-details/components/ClaimNotes.tsx
+++ b/src/components/claims/claim-details/components/ClaimNotes.tsx
@@ -98,7 +98,7 @@ const ClaimNotes: React.FC<Props> = ({ notes, claimId, refetchPage }) => (
             <ListItem key={note.date}>
               <ClaimNote component="p">{note.text}</ClaimNote>
               <ClaimNoteDate component="span">
-                {format(parseISO(note.date), 'yyyy-MM-dd hh:mm:ss')}
+                {format(parseISO(note.date), 'yyyy-MM-dd HH:mm:ss')}
               </ClaimNoteDate>
             </ListItem>
           ))}

--- a/src/components/claims/claim-details/components/ClaimPayments.tsx
+++ b/src/components/claims/claim-details/components/ClaimPayments.tsx
@@ -107,7 +107,7 @@ const ClaimPayments: React.SFC<Props> = ({
               </PaymentTableCell>
               <PaymentTableCell>{payment!.note}</PaymentTableCell>
               <PaymentTableCell>
-                {format(parseISO(payment!.timestamp), 'yyyy-MM-dd hh:mm:ss')}
+                {format(parseISO(payment!.timestamp), 'yyyy-MM-dd HH:mm:ss')}
               </PaymentTableCell>
               <PaymentTableCell>
                 {payment!.exGratia ? <Checkmark /> : <Cross />}

--- a/src/components/claims/claims-list/components/ClaimListHeader.tsx
+++ b/src/components/claims/claims-list/components/ClaimListHeader.tsx
@@ -49,9 +49,9 @@ export const ClaimListHeader: React.FC<{
 
   return (
     <Table.Header>
-      <Table.HeaderCell>Member ID</Table.HeaderCell>
+      <Table.HeaderCell width={1}>Member ID</Table.HeaderCell>
       <Table.HeaderCell
-        width={6}
+        width={3}
         sorted={column === ClaimSortColumn.Date ? sortDirection : undefined}
         onClick={() => sortTable(ClaimSortColumn.Date)}
       >
@@ -65,14 +65,14 @@ export const ClaimListHeader: React.FC<{
         Type
       </Table.HeaderCell>
       <Table.HeaderCell
-        width={6}
+        width={1}
         sorted={column === ClaimSortColumn.State ? sortDirection : undefined}
         onClick={() => sortTable(ClaimSortColumn.State)}
       >
         State
       </Table.HeaderCell>
       <Table.HeaderCell
-        width={6}
+        width={2}
         sorted={column === ClaimSortColumn.Reserve ? sortDirection : undefined}
         onClick={() => sortTable(ClaimSortColumn.Reserve)}
       >

--- a/src/components/claims/claims-list/components/ClaimListItem.tsx
+++ b/src/components/claims/claims-list/components/ClaimListItem.tsx
@@ -64,7 +64,13 @@ export const ClaimListItem: React.FC<{
           <Capitalized>{item.state}</Capitalized>
         </Badge>
       </Table.Cell>
-      <Table.Cell>{item.reserves && formatMoney(item.reserves)}</Table.Cell>
+      <Table.Cell>
+        {item.reserves &&
+          formatMoney(item.reserves, {
+            useGrouping: true,
+            maximumFractionDigits: 0,
+          })}
+      </Table.Cell>
     </FadeInLinkRow>
   )
 }

--- a/src/components/member/tabs/ClaimsTab.tsx
+++ b/src/components/member/tabs/ClaimsTab.tsx
@@ -48,15 +48,6 @@ const ClaimsTabComponent: React.FC<{
   if (loading || !claims) {
     return <LoadingMessage paddingTop="25vh" />
   }
-
-  if (claims.length === 0) {
-    return (
-      <StandaloneMessage paddingTop="10vh">
-        Claims list is empty
-      </StandaloneMessage>
-    )
-  }
-
   return (
     <FadeIn>
       <HeaderWrapper>
@@ -142,7 +133,7 @@ const ClaimsTabComponent: React.FC<{
                       })
                   }}
                 >
-                  Save
+                  Add
                 </Button>
               </Spacing>
             </>
@@ -157,15 +148,20 @@ const ClaimsTabComponent: React.FC<{
           )}
         </FormWrapper>
       </HeaderWrapper>
-      <Table celled selectable>
-        <ClaimListHeader />
-
-        <Table.Body>
-          {claims.map((item, index) => (
-            <ClaimListItem key={item.id} item={item} index={index} />
-          ))}
-        </Table.Body>
-      </Table>
+      {claims.length === 0 ? (
+        <StandaloneMessage paddingTop="10vh">
+          No claims for member
+        </StandaloneMessage>
+      ) : (
+        <Table celled selectable>
+          <ClaimListHeader />
+          <Table.Body>
+            {claims.map((item, index) => (
+              <ClaimListItem key={item.id} item={item} index={index} />
+            ))}
+          </Table.Body>
+        </Table>
+      )}
     </FadeIn>
   )
 }

--- a/src/components/member/tabs/ClaimsTab.tsx
+++ b/src/components/member/tabs/ClaimsTab.tsx
@@ -43,7 +43,7 @@ const ClaimsTabComponent: React.FC<{
 
   const [showForm, setShowForm] = React.useState(false)
   const [claimSource, setClaimSource] = React.useState<ClaimSource | null>(null)
-  const [claimDate, setClaimDate] = React.useState<Date | null>(null)
+  const [claimDate, setClaimDate] = React.useState<Date>(new Date())
 
   if (loading || !claims) {
     return <LoadingMessage paddingTop="25vh" />
@@ -74,6 +74,7 @@ const ClaimsTabComponent: React.FC<{
                   setDate={(date) => setClaimDate(date)}
                   placeholder="Notification date"
                   maxDate={new Date()}
+                  showTimePicker
                 />
               </Spacing>
               <Spacing left={'small'}>
@@ -83,7 +84,7 @@ const ClaimsTabComponent: React.FC<{
                   color="danger"
                   onClick={() => {
                     setShowForm(false)
-                    setClaimDate(null)
+                    setClaimDate(new Date())
                     setClaimSource(null)
                   }}
                 >
@@ -113,7 +114,7 @@ const ClaimsTabComponent: React.FC<{
                     })
                       .then(() => {
                         setShowForm(false)
-                        setClaimDate(null)
+                        setClaimDate(new Date())
                         setClaimSource(null)
                         refetch().then(() => {
                           showNotification({

--- a/src/components/member/tabs/account-tab/MonthlyEntriesTable.tsx
+++ b/src/components/member/tabs/account-tab/MonthlyEntriesTable.tsx
@@ -74,7 +74,7 @@ export const MonthlyEntriesTableComponent: React.FC<{
                           <br />
                           {format(
                             parseISO(monthlyEntry.addedAt),
-                            'yyyy-MM-dd hh:mm:ss',
+                            'yyyy-MM-dd HH:mm:ss',
                           )}
                         </Grid.Column>
                       </Grid.Row>

--- a/src/components/member/tabs/contracts-tab/agreement/AgreementInfo.tsx
+++ b/src/components/member/tabs/contracts-tab/agreement/AgreementInfo.tsx
@@ -81,7 +81,10 @@ export const AgreementInfo: React.FC<{ agreement: GenericAgreement }> = ({
         <InfoText>{convertEnumToTitle(agreement.lineOfBusinessName)}</InfoText>
       </InfoRow>
       <InfoRow>
-        Premium <InfoText>{formatMoney(agreement.premium)}</InfoText>
+        Premium{' '}
+        <InfoText>
+          {formatMoney(agreement.premium, { minimumFractionDigits: 0 })}
+        </InfoText>
       </InfoRow>
       <InfoRow>
         Status <InfoText>{convertEnumToTitle(agreement.status)}</InfoText>

--- a/src/components/member/tabs/contracts-tab/agreement/AgreementsTable.tsx
+++ b/src/components/member/tabs/contracts-tab/agreement/AgreementsTable.tsx
@@ -76,7 +76,7 @@ export const AgreementsTable: React.FC<{
                 selected={isSelected}
                 status={agreement.status}
               >
-                {formatMoney(agreement.premium)}
+                {formatMoney(agreement.premium, { minimumFractionDigits: 0 })}
               </SelectableTableCell>
               <SelectableTableCell
                 selected={isSelected}

--- a/src/components/shared/navigation/sidebar/VerticalMenu.tsx
+++ b/src/components/shared/navigation/sidebar/VerticalMenu.tsx
@@ -274,7 +274,7 @@ export const VerticalMenuComponent: React.FC<any & { history: History }> = ({
                   <Inbox />
                   <MenuText>Questions</MenuText>
                 </MenuItem>
-                <MenuItem to="/claims">
+                <MenuItem to="/claims/list/1">
                   <ShieldShaded />
                   <MenuText>Claims</MenuText>
                 </MenuItem>

--- a/src/components/shared/paginator/Paginator.tsx
+++ b/src/components/shared/paginator/Paginator.tsx
@@ -70,7 +70,7 @@ export const Paginator = <T extends object>({
     <>
       <Table celled selectable sortable>
         {tableHeader}
-        {pagedItems.length ? (
+        {pagedItems.length > 0 && (
           <Table.Body>
             {pagedItems.map((item, index) => (
               <React.Fragment key={keyName ? '' + item[keyName] : index}>
@@ -78,8 +78,6 @@ export const Paginator = <T extends object>({
               </React.Fragment>
             ))}
           </Table.Body>
-        ) : (
-          <></>
         )}
       </Table>
       {totalPages > 1 && (

--- a/src/containers/ClaimsPage.tsx
+++ b/src/containers/ClaimsPage.tsx
@@ -1,9 +1,9 @@
-import { Claims } from 'components/claims'
+import { ClaimsList } from 'components/claims'
 import { ListPage } from 'components/shared'
 import React from 'react'
 
-export const ClaimsPage = () => (
+export const ClaimsPage = (props) => (
   <ListPage>
-    <Claims />
+    <ClaimsList {...props} />
   </ListPage>
 )

--- a/src/graphql/use-dashboard-numbers.tsx
+++ b/src/graphql/use-dashboard-numbers.tsx
@@ -11,7 +11,7 @@ type DashboardNumbersReturnTuple = [
 
 export const useDashboardNumbers = (): DashboardNumbersReturnTuple => {
   const queryResult = useGetDashboardNumbersQuery({
-    pollInterval: 1000 * 60,
+    pollInterval: 1000 * 5,
   })
   const dashboardNumbers = queryResult.data?.dashboardNumbers as
     | DashboardNumbers

--- a/src/routes/ClaimsPageRoute.tsx
+++ b/src/routes/ClaimsPageRoute.tsx
@@ -9,9 +9,13 @@ const ClaimsPageRoute = ({ store }) => (
   <Switch>
     <Route
       exact
-      path="/claims"
+      path="/claims/list/:page"
       render={() => (
-        <PrivateRoute component={ClaimsPage} path="/claims" store={store} />
+        <PrivateRoute
+          component={ClaimsPage}
+          path="/claims/list/:page"
+          store={store}
+        />
       )}
     />
     <Route

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -5,7 +5,6 @@ export const reactPageRoutes = [
   { path: '/login/**', Component: Routes.LoginPageRoute, exact: true },
   { path: '/members', Component: Routes.MembersPageRoute },
   { path: '/claims/**', Component: Routes.ClaimsPageRoute, exact: true },
-  { path: '/claims', Component: Routes.ClaimsPageRoute, exact: true },
   { path: '/questions/**', Component: Routes.QuestionsPageRoute, exact: true },
   { path: '/questions', Component: Routes.QuestionsPageRoute, exact: true },
   { path: '/dashborad', Component: Routes.DashboardPageRoute, exact: true },


### PR DESCRIPTION
# Jira Issue: []

## What?
- Allow ability to create claim from member page has no claims
- Add selected page in pagination for claims list
- Fix widths of columns in claims list
- Remove decimals for reserves and add grouping

## Why?
- You couldn't create a claim from claims tab if the member didn't have any claims due to early return
- Navigation back and forth between claims list/claim always ended up on page 1
- Readability of new design could be improved slightly

## Optional screenshots

Before:
![image](https://user-images.githubusercontent.com/20777544/105883632-5c080880-6007-11eb-88c1-ab8c4bd7b683.png)


After:
![image](https://user-images.githubusercontent.com/20777544/105883744-7b069a80-6007-11eb-82fe-fefb9e7d1047.png)

Before:
![image](https://user-images.githubusercontent.com/20777544/105884246-10099380-6008-11eb-9181-8ae518e0946a.png)

After:
![image](https://user-images.githubusercontent.com/20777544/105884282-1ac42880-6008-11eb-9afc-118b7298efe0.png)


## Optional checklist
- [x] Updated `src/changelog.ts`
- [x] Codescouted
- [ ] Unit tests written
- [x] Tested locally

