### PR TITLE
add some simple totals row to the claim payments list

### DIFF
--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -12,6 +12,11 @@ export interface Change {
 
 export const changelog: ReadonlyArray<Change> = [
   {
+    date: '2021-02-01',
+    change: 'Add amount totals to the claims payment list.',
+    authorGithubHandle: 'bystam',
+  },
+  {
     date: '2021-01-26',
     change: 'Claims list fixes, decrease Dashborad polling interval',
     authorGithubHandle: 'vonElfvin',

--- a/src/components/claims/claim-details/components/ClaimPayments.tsx
+++ b/src/components/claims/claim-details/components/ClaimPayments.tsx
@@ -49,7 +49,7 @@ const ClaimPayments: React.SFC<Props> = ({
   identity,
   market,
 }) => {
-  let total = payments
+  let totalAmount = payments
     .map((payment) => +payment?.amount?.amount)
     .reduce((acc, amount) => acc + amount, 0)
   let totalDeductible = payments
@@ -123,20 +123,20 @@ const ClaimPayments: React.SFC<Props> = ({
               <PaymentTableCell>{payment!.status}</PaymentTableCell>
             </MuiTableRow>
           ))}
-          {total > 0 && (
+          {totalAmount > 0 && (
             <>
               <MuiTableRow>
                 <MuiTableCell rowSpan={3} colSpan={5} />
                 <PaymentTableCell colSpan={2}>
-                  <b>Total: </b>
+                  <b>Amount Total: </b>
                 </PaymentTableCell>
                 <PaymentTableCell align="right">
-                  {total.toFixed(2)}&nbsp;{payments[0]!.amount.currency}
+                  {totalAmount.toFixed(2)}&nbsp;{payments[0]!.amount.currency}
                 </PaymentTableCell>
               </MuiTableRow>
               <MuiTableRow>
                 <PaymentTableCell colSpan={2}>
-                  <b>Total deductible: </b>
+                  <b>Deductible Total: </b>
                 </PaymentTableCell>
                 <PaymentTableCell align="right">
                   {totalDeductible.toFixed(2)}&nbsp;

--- a/src/components/claims/claim-details/components/ClaimPayments.tsx
+++ b/src/components/claims/claim-details/components/ClaimPayments.tsx
@@ -49,6 +49,13 @@ const ClaimPayments: React.SFC<Props> = ({
   identity,
   market,
 }) => {
+  let total = payments
+    .map((payment) => +payment?.amount?.amount)
+    .reduce((acc, amount) => acc + amount, 0)
+  let totalDeductible = payments
+    .map((payment) => +payment?.deductible?.amount)
+    .reduce((acc, amount) => acc + amount, 0)
+
   return (
     <Paper>
       <h3>Payments</h3>
@@ -100,10 +107,10 @@ const ClaimPayments: React.SFC<Props> = ({
             >
               <PaymentTableCell>{payment!.id}</PaymentTableCell>
               <PaymentTableCell>
-                {payment!.amount.amount} {payment!.amount.currency}
+                {payment!.amount.amount}&nbsp;{payment!.amount.currency}
               </PaymentTableCell>
               <PaymentTableCell>
-                {payment!.deductible.amount} {payment!.deductible.currency}
+                {payment!.deductible.amount}&nbsp;{payment!.deductible.currency}
               </PaymentTableCell>
               <PaymentTableCell>{payment!.note}</PaymentTableCell>
               <PaymentTableCell>
@@ -116,6 +123,28 @@ const ClaimPayments: React.SFC<Props> = ({
               <PaymentTableCell>{payment!.status}</PaymentTableCell>
             </MuiTableRow>
           ))}
+          {total > 0 && (
+            <>
+              <MuiTableRow>
+                <MuiTableCell rowSpan={3} colSpan={5} />
+                <PaymentTableCell colSpan={2}>
+                  <b>Total: </b>
+                </PaymentTableCell>
+                <PaymentTableCell align="right">
+                  {total.toFixed(2)}&nbsp;{payments[0]!.amount.currency}
+                </PaymentTableCell>
+              </MuiTableRow>
+              <MuiTableRow>
+                <PaymentTableCell colSpan={2}>
+                  <b>Total deductible: </b>
+                </PaymentTableCell>
+                <PaymentTableCell align="right">
+                  {totalDeductible.toFixed(2)}&nbsp;
+                  {payments[0]!.deductible.currency}
+                </PaymentTableCell>
+              </MuiTableRow>
+            </>
+          )}
         </MuiTableBody>
       </PaymentTable>
 


### PR DESCRIPTION
# Jira Issue: [HVG-783] (bonus task)

## What?
Adds two rows at the bottom of the claims payment list that contains the total amount and deductible.

## Why?
IEX have asked for a simple way to just summarise this in the UI so that they don't have to do it manually.

## Optional screenshots
<img width="1166" alt="Screenshot 2021-02-01 at 11 44 09" src="https://user-images.githubusercontent.com/2649932/106448609-4d947380-6483-11eb-860d-c1a76880ca96.png">

## Optional checklist
- [x] Updated `src/changelog.ts`
- [x] Codescouted
- [ ] Unit tests written
- [x] Tested locally



[HVG-783]: https://hedvig.atlassian.net/browse/HVG-783