### PR TITLE
Remove logout shortcut, move latest claim to L, add clickable actions

### DIFF
--- a/src/components/shared/navigation/sidebar/VerticalMenu.tsx
+++ b/src/components/shared/navigation/sidebar/VerticalMenu.tsx
@@ -305,15 +305,8 @@ export const VerticalMenuComponent: React.FC<any & { history: History }> = ({
       },
     },
     {
-      label: 'Logout',
-      keys: [Keys.Option, Keys.L],
-      onResolve: () => {
-        authLogOut_()
-      },
-    },
-    {
       label: 'Latest claim',
-      keys: [Keys.Option, Keys.Backspace],
+      keys: [Keys.Option, Keys.L],
       onResolve: () => {
         if (!latestClaim.current) {
           return

--- a/src/utils/hooks/command-line-hook.tsx
+++ b/src/utils/hooks/command-line-hook.tsx
@@ -37,14 +37,14 @@ const CharacterBadge = styled.div`
   margin-right: 0.4em;
 `
 
-const ResultItemWrapper = styled.div<{ selected: boolean }>`
+const ResultItemWrapper = styled.div<{ highlighted: boolean }>`
   padding: 1em 3.5em;
   padding-right: 1em;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background-color: ${({ selected }) =>
-    selected ? 'rgba(0, 0, 0, 0.1)' : 'transparent'};
+  background-color: ${({ highlighted }) =>
+    highlighted ? 'rgba(0, 0, 0, 0.1)' : 'transparent'};
 `
 
 const ResultItemContent = styled.div`
@@ -67,15 +67,27 @@ const SearchWrapper = styled.div`
 const SearchResultWrapper = styled.div``
 
 const ResultItem: React.FC<{
-  label: string
-  keys: Key[]
+  action: CommandLineAction
   selected?: boolean
-}> = ({ label, keys, selected = false }) => {
+  hide: () => void
+}> = ({ action, selected = false, hide }) => {
+  const [highlighted, setHighlighted] = useState(selected)
+  useEffect(() => {
+    setHighlighted(selected)
+  }, [selected])
   return (
-    <ResultItemWrapper selected={selected}>
-      <FourthLevelHeadline>{label}</FourthLevelHeadline>
+    <ResultItemWrapper
+      highlighted={highlighted}
+      onClick={() => {
+        action.onResolve()
+        hide()
+      }}
+      onMouseEnter={() => setHighlighted(true)}
+      onMouseLeave={() => setHighlighted(selected)}
+    >
+      <FourthLevelHeadline>{action.label}</FourthLevelHeadline>
       <ResultItemContent>
-        {keys.map(({ hint }) => (
+        {action.keys.map(({ hint }) => (
           <CharacterBadge key={hint}>
             <Paragraph style={{ fontSize: '0.8em', fontWeight: 'bold' }}>
               {hint}
@@ -198,17 +210,17 @@ export const CommandLineComponent: React.FC<{
       <SearchResultWrapper>
         {searchResult
           .slice(firstActionIndex, firstActionIndex + maxActions)
-          .map(({ label, keys }, index) => (
+          .map((action, index) => (
             <FadeIn
               delay={`${Math.abs(
                 selectedActionIndex - firstActionIndex - index,
               ) * 40}ms`}
               duration={400}
-              key={`${label} ${searchValue}`}
+              key={`${action.label} ${searchValue}`}
             >
               <ResultItem
-                label={label}
-                keys={keys}
+                hide={hide}
+                action={action}
                 selected={firstActionIndex + index === selectedActionIndex}
               />
             </FadeIn>

--- a/src/utils/hooks/command-line-hook.tsx
+++ b/src/utils/hooks/command-line-hook.tsx
@@ -19,9 +19,9 @@ import {
 
 const CommandLineWindow = styled.div`
   position: absolute;
-  top: 50%;
+  top: 20vh;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translateX(-50%);
   background-color: rgba(255, 255, 255, 1);
   box-shadow: -1px -1px 42px 0px rgba(0, 0, 0, 0.25);
   border-radius: 0.3em;
@@ -37,14 +37,19 @@ const CharacterBadge = styled.div`
   margin-right: 0.4em;
 `
 
-const ResultItemWrapper = styled.div<{ highlighted: boolean }>`
+const ResultItemWrapper = styled.div<{ selected: boolean }>`
   padding: 1em 3.5em;
   padding-right: 1em;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background-color: ${({ highlighted }) =>
-    highlighted ? 'rgba(0, 0, 0, 0.1)' : 'transparent'};
+  background-color: ${({ selected }) =>
+    selected ? 'rgba(0, 0, 0, 0.1)' : 'transparent'};
+
+  &:hover {
+    cursor: pointer;
+    background-color: rgba(0, 0, 0, 0.1) !important;
+  }
 `
 
 const ResultItemContent = styled.div`
@@ -71,19 +76,13 @@ const ResultItem: React.FC<{
   selected?: boolean
   hide: () => void
 }> = ({ action, selected = false, hide }) => {
-  const [highlighted, setHighlighted] = useState(selected)
-  useEffect(() => {
-    setHighlighted(selected)
-  }, [selected])
   return (
     <ResultItemWrapper
-      highlighted={highlighted}
+      selected={selected}
       onClick={() => {
         action.onResolve()
         hide()
       }}
-      onMouseEnter={() => setHighlighted(true)}
-      onMouseLeave={() => setHighlighted(selected)}
     >
       <FourthLevelHeadline>{action.label}</FourthLevelHeadline>
       <ResultItemContent>


### PR DESCRIPTION
# Jira Issue: []

## What?
- Allow clicking on search results
- Fix command line Y position
- Remove logout shortcut
- Change Option-L to go to last claim

## Why?
- Because clicking is a natural thing to want to do sometimes
- The commandline was bouncing up and down when searching
- Option-Backspace was used to remove whole words in an input, also no-one ever logs out so it's weird to have

## Optional screenshots

## Optional checklist
- [ ] Updated `src/changelog.ts`
- [ ] Codescouted
- [ ] Unit tests written
- [x] Tested locally

