### PR TITLE
Display the claim note handler reference if there is one

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -5018,6 +5018,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "handlerReference",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -13599,11 +13611,7 @@
       {
         "name": "skip",
         "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
         "args": [
           {
             "name": "if",
@@ -13624,11 +13632,7 @@
       {
         "name": "include",
         "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
         "args": [
           {
             "name": "if",
@@ -13649,10 +13653,7 @@
       {
         "name": "deprecated",
         "description": "Marks an element of a GraphQL schema as no longer supported.",
-        "locations": [
-          "FIELD_DEFINITION",
-          "ENUM_VALUE"
-        ],
+        "locations": ["FIELD_DEFINITION", "ENUM_VALUE"],
         "args": [
           {
             "name": "reason",

--- a/schema.graphql
+++ b/schema.graphql
@@ -526,7 +526,7 @@ type UnknownIncentive {
 }
 
 union Incentive =
-  MonthlyPercentageDiscountFixedPeriod
+    MonthlyPercentageDiscountFixedPeriod
   | FreeMonths
   | CostDeduction
   | NoDiscount
@@ -969,6 +969,7 @@ type ClaimItemSet {
 type ClaimNote {
   text: String!
   date: LocalDateTime!
+  handlerReference: String
 }
 
 type ClaimTranscription {
@@ -1002,7 +1003,7 @@ enum ClaimTypes {
   TestClaim
 }
 union ClaimType =
-  TheftClaim
+    TheftClaim
   | AccidentalDamageClaim
   | AssaultClaim
   | WaterDamageClaim
@@ -1206,7 +1207,7 @@ enum ClaimState {
 enum ClaimPaymentType {
   Manual
   Automatic
-  IndemnityCost,
+  IndemnityCost
   Expense
 }
 

--- a/src/api/generated/graphql.tsx
+++ b/src/api/generated/graphql.tsx
@@ -291,6 +291,7 @@ export type ClaimNote = {
   __typename?: 'ClaimNote'
   text: Scalars['String']
   date: Scalars['LocalDateTime']
+  handlerReference?: Maybe<Scalars['String']>
 }
 
 export type ClaimNoteInput = {

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -12,6 +12,11 @@ export interface Change {
 
 export const changelog: ReadonlyArray<Change> = [
   {
+    date: '2021-04-09',
+    change: 'Automatically store who made a claim note, bye bye initials // JP',
+    authorGithubHandle: 'palmenhq',
+  },
+  {
     date: '2021-04-06',
     change:
       'Shortcut fixes! Added search pagination, fix some bugs and improve speed slightly. ',

--- a/src/components/claims/claim-details/components/ClaimNotes.tsx
+++ b/src/components/claims/claim-details/components/ClaimNotes.tsx
@@ -76,9 +76,10 @@ const ClaimNote = withStyles({
   },
 })(MuiTypography)
 
-const ClaimNoteDate = withStyles({
+const ClaimNoteFooter = withStyles({
   root: {
     fontSize: '0.875rem',
+    textAlign: 'right',
   },
 })(MuiTypography)
 
@@ -97,9 +98,15 @@ const ClaimNotes: React.FC<Props> = ({ notes, claimId, refetchPage }) => (
           {sortNotesByDate(notes).map((note) => (
             <ListItem key={note.date}>
               <ClaimNote component="p">{note.text}</ClaimNote>
-              <ClaimNoteDate component="span">
+              <ClaimNoteFooter component="span">
+                {note.handlerReference && (
+                  <>
+                    {note.handlerReference}
+                    <br />
+                  </>
+                )}
                 {format(parseISO(note.date), 'yyyy-MM-dd HH:mm:ss')}
-              </ClaimNoteDate>
+              </ClaimNoteFooter>
             </ListItem>
           ))}
         </MuiList>

--- a/src/components/claims/claim-details/data.ts
+++ b/src/components/claims/claim-details/data.ts
@@ -62,6 +62,7 @@ export const CLAIM_PAGE_QUERY = gql`
       notes {
         text
         date
+        handlerReference
       }
       transcriptions {
         text

--- a/src/components/claims/claim-details/index.tsx
+++ b/src/components/claims/claim-details/index.tsx
@@ -87,18 +87,20 @@ const ClaimPage: React.FC<Props> = ({ ...props }) => (
                       )}
                     </Grid>
                     <Grid item xs={12} sm={12} md={4}>
-                      <ClaimInformation
-                        recordingUrl={recordingUrl!}
-                        registrationDate={registrationDate}
-                        state={state!}
-                        claimId={props.match.params.claimId}
-                        coveringEmployee={coveringEmployee!}
-                        memberId={props.match.params.memberId}
-                        refetchPage={refetch}
-                        contracts={member!!.contracts}
-                        selectedContract={contract ?? null}
-                        selectedAgreement={agreement ?? null}
-                      />
+                      {member && (
+                        <ClaimInformation
+                          recordingUrl={recordingUrl!}
+                          registrationDate={registrationDate}
+                          state={state!}
+                          claimId={props.match.params.claimId}
+                          coveringEmployee={coveringEmployee!}
+                          memberId={props.match.params.memberId}
+                          refetchPage={refetch}
+                          contracts={member.contracts}
+                          selectedContract={contract ?? null}
+                          selectedAgreement={agreement ?? null}
+                        />
+                      )}
                     </Grid>
                     <Grid item xs={12} sm={12} md={4}>
                       <ClaimTypeForm


### PR DESCRIPTION
Frontend of https://github.com/HedvigInsurance/back-office/pull/352

## Why?
- For traceability and so iex don't have to remember all the initials

## Optional screenshots
<img width="800" alt="Screenshot 2021-04-09 at 14 31 28" src="https://user-images.githubusercontent.com/3954425/114180692-d24ab480-9940-11eb-86b3-9758050ab2f8.png">


## Optional checklist
- [x] Updated `src/changelog.ts`
- [ ] Codescouted
- [ ] Unit tests written
- [ ] Tested locally

