### PR TITLE
Fix secure cookies that didn't work behind proxy with ssl termination

### DIFF
--- a/src/server/serverEntry.ts
+++ b/src/server/serverEntry.ts
@@ -71,6 +71,8 @@ const logger = loggerFactory.getLogger('app')
 const app = new Koa()
 const router = new Router()
 
+app.proxy = true
+
 if (config.useHelmet) {
   app.use(
     koaHelmet({


### PR DESCRIPTION
# Jira Issue: []

## What?
- Fix secure cookies that didn't work behind proxy with ssl termination

## Why?
- Apparently Koa checks so it doesn't send secure cookies over an insecure connection but this is desableable by setting it to proxy mode (which should be enabled anyways) as Heroku will send a `X-Forwarded-Proto: https` header

## Optional screenshots

## Optional checklist
- [ ] Updated `src/changelog.ts`
- [ ] Codescouted
- [ ] Unit tests written
- [x] Tested locally

