### PR TITLE
Add click to copy for ssn in claims view, move files tab to the right

### DIFF
--- a/shared/hedvig-ui/popover.tsx
+++ b/shared/hedvig-ui/popover.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled'
 import React from 'react'
 
 const Contents = styled.div`
+  text-align: center;
   position: absolute;
   top: 0;
   left: 50%;

--- a/src/components/claims/claim-details/components/MemberInformation.tsx
+++ b/src/components/claims/claim-details/components/MemberInformation.tsx
@@ -6,6 +6,7 @@ import {
   useClaimMemberContractsMasterInceptionQuery,
 } from 'api/generated/graphql'
 import { MemberFlag } from 'components/member/shared/member-flag'
+import copy from 'copy-to-clipboard'
 import { format, formatDistance, parseISO } from 'date-fns'
 import { Loadable } from 'hedvig-ui/loadable'
 import { ErrorText, ThirdLevelHeadline } from 'hedvig-ui/typography'
@@ -73,6 +74,13 @@ const MemberName = styled('h2')({
   marginBottom: '2rem',
 })
 
+const ClickableText = styled.span`
+  color: ${({ theme }) => theme.accent};
+  &:hover {
+    cursor: pointer;
+  }
+`
+
 export const MemberInformation: React.FC<{
   claimId: string
   memberId: string
@@ -137,7 +145,19 @@ export const MemberInformation: React.FC<{
           <InfoRow>
             Personal number
             <InfoText>
-              {member?.personalNumber ? formatSsn(member.personalNumber) : '-'}
+              {member?.personalNumber ? (
+                <Popover contents={<>Click to copy</>}>
+                  <ClickableText
+                    onClick={() => {
+                      copy(member.personalNumber!)
+                    }}
+                  >
+                    {formatSsn(member.personalNumber)}
+                  </ClickableText>
+                </Popover>
+              ) : (
+                'No personal number'
+              )}
             </InfoText>
           </InfoRow>
           {member?.sanctionStatus && (
@@ -165,12 +185,14 @@ export const MemberInformation: React.FC<{
                 Postal code
                 <InfoText>{formatPostalCode(address.postalCode)}</InfoText>
               </InfoRow>
-              <InfoRow>
-                City
-                <InfoText>
-                  {convertEnumOrSentenceToTitle(address.city ?? '')}
-                </InfoText>
-              </InfoRow>
+              {address.city && (
+                <InfoRow>
+                  City
+                  <InfoText>
+                    {convertEnumOrSentenceToTitle(address.city)}
+                  </InfoText>
+                </InfoRow>
+              )}
             </InfoSection>
           )}
 

--- a/src/components/member/tabs/account-tab/AddEntryForm.tsx
+++ b/src/components/member/tabs/account-tab/AddEntryForm.tsx
@@ -111,10 +111,11 @@ const AddEntryFormComponent: React.FC<{
       ...data,
       fromDate: format(new Date(), 'yyyy-MM-dd'),
       amount: {
-        amount: data.amount,
+        amount: data.amount.amount,
         currency: preferredCurrency,
       },
     }
+
     addAccountEntry({
       variables: {
         memberId,

--- a/src/components/member/tabs/index.tsx
+++ b/src/components/member/tabs/index.tsx
@@ -48,38 +48,38 @@ export const memberPagePanes = (props, memberId, member, isHinting) => [
     ),
   },
   {
-    tabName: 'files',
-    menuItem: `Files ${isHinting ? '(3)' : ''}`,
-    render: () => (
-      <TabItem props={{ ...props, memberId }} TabContent={MemberFile} />
-    ),
-  },
-  {
     tabName: 'contracts',
-    menuItem: `Contracts ${isHinting ? '(4)' : ''}`,
+    menuItem: `Contracts ${isHinting ? '(3)' : ''}`,
     render: () => (
       <TabItem props={{ ...props, memberId }} TabContent={ContractTab} />
     ),
   },
   {
     tabName: 'quotes',
-    menuItem: `Quotes ${isHinting ? '(5)' : ''}`,
+    menuItem: `Quotes ${isHinting ? '(4)' : ''}`,
     render: () => (
       <TabItem props={{ ...props, memberId }} TabContent={Quotes} />
     ),
   },
   {
     tabName: 'payments',
-    menuItem: `Payments ${isHinting ? '(6)' : ''}`,
+    menuItem: `Payments ${isHinting ? '(5)' : ''}`,
     render: () => (
       <TabItem props={{ ...props, memberId }} TabContent={PaymentsTab} />
     ),
   },
   {
     tabName: 'account',
-    menuItem: `Account ${isHinting ? '(7)' : ''}`,
+    menuItem: `Account ${isHinting ? '(6)' : ''}`,
     render: () => (
       <TabItem props={{ ...props, memberId }} TabContent={AccountTab} />
+    ),
+  },
+  {
+    tabName: 'files',
+    menuItem: `Files ${isHinting ? '(7)' : ''}`,
+    render: () => (
+      <TabItem props={{ ...props, memberId }} TabContent={MemberFile} />
     ),
   },
   {


### PR DESCRIPTION
# Jira Issue: []

## What?
- Add click to copy to ssn in claims view
- Move files more to the right
- Fix so we can create account entries

## Why?
- Ssn is used for FOSS/GSR checkups and the format was wrong "copy wise" but correct readable wise
- Files is less used and since we use CTRL-1 to CTRL-9 as hotkey, let's move the more used ones to the left a bit
- Account entries were broken

## Optional screenshots

## Optional checklist
- [ ] Updated `src/changelog.ts`
- [ ] Codescouted
- [ ] Unit tests written
- [x] Tested locally

