### PR TITLE
Fix: Remove double audio stream

### DIFF
--- a/shared/hedvig-ui/typography.tsx
+++ b/shared/hedvig-ui/typography.tsx
@@ -9,6 +9,12 @@ export const FourthLevelHeadline = styled('h4')`
 `
 export const Paragraph = styled.p``
 
+export const Label = styled('p')`
+  font-size: 0.95rem;
+  margin-bottom: 0.4em;
+  color: ${({ theme }) => theme.semiStrongForeground};
+`
+
 export const Capitalized = styled.div`
   display: inline-block;
   ::first-letter {

--- a/src/components/claims/claim-details/components/ClaimInformation.tsx
+++ b/src/components/claims/claim-details/components/ClaimInformation.tsx
@@ -18,8 +18,14 @@ import {
 } from 'graphql/use-update-claim-state'
 import { InfoRow, InfoText } from 'hedvig-ui/info-row'
 import { Loadable } from 'hedvig-ui/loadable'
-import { ErrorText, Label, Paragraph } from 'hedvig-ui/typography'
-import React from 'react'
+import {
+  ErrorText,
+  Label,
+  Paragraph,
+  ThirdLevelHeadline,
+} from 'hedvig-ui/typography'
+import React, { useState } from 'react'
+import { CloudArrowDownFill } from 'react-bootstrap-icons'
 import { currentAgreementForContract } from 'utils/contract'
 import { sleep } from 'utils/sleep'
 import { convertEnumToTitle } from 'utils/text'
@@ -46,23 +52,61 @@ const validateSelectEmployeeClaimOption = (
   return value === 'True'
 }
 
-const getUrlWithoutParameters = (recordingUrl): string => {
-  const regex = recordingUrl.split(/\?/)
-  return regex[0]
-}
-
-const Audio = styled('audio')({
-  width: '100%',
-})
-
-const DownloadClaimFile = styled('a')({
-  display: 'block',
-  marginTop: '0.5rem',
-})
-
 const SelectWrapper = styled('div')({
   marginTop: '1.0rem',
 })
+
+const Audio = styled('audio')`
+  width: 100%;
+`
+
+const ClaimAudioWrapper = styled.div`
+  display: flex;
+  width: 100%;
+  margin-right: 1em;
+  justify-content: space-between;
+  align-items: center;
+`
+
+const DownloadWrapper = styled.a`
+  font-size: 1.5em;
+  margin: 0.5em 0em;
+  margin-left: 0.5em;
+  padding-top: 0.4em;
+`
+
+const DownloadButton = styled(CloudArrowDownFill)`
+  color: ${({ theme }) => theme.foreground};
+`
+
+const ClaimAudio: React.FC<{ recordingUrl: string }> = ({ recordingUrl }) => {
+  const [canPlay, setCanPlay] = useState<null | boolean>(null)
+
+  if (canPlay === false) {
+    return null
+  }
+
+  return (
+    <ClaimAudioWrapper>
+      <Audio
+        controls
+        controlsList="nodownload"
+        onCanPlay={() => setCanPlay(true)}
+        onError={() => setCanPlay(false)}
+      >
+        <source src={recordingUrl} type="audio/aac" />
+      </Audio>
+      <DownloadWrapper
+        href={recordingUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        download
+      >
+        <DownloadButton />
+      </DownloadWrapper>
+    </ClaimAudioWrapper>
+  )
+}
 
 export const ClaimInformation: React.FC<Props> = ({ claimId, memberId }) => {
   const {
@@ -90,46 +134,18 @@ export const ClaimInformation: React.FC<Props> = ({ claimId, memberId }) => {
 
   return (
     <Paper>
-      <h3>Claim Information</h3>
+      <ThirdLevelHeadline>Claim Information</ThirdLevelHeadline>
       {queryError && <ErrorText>{queryError.message}</ErrorText>}
 
       <Loadable loading={claimInformationLoading}>
-        <div>
-          <InfoRow>
-            Registered at
-            <InfoText>
-              {registrationDate &&
-                format(parseISO(registrationDate), 'yyyy-MM-dd HH:mm:ss')}
-            </InfoText>
-          </InfoRow>
-          {recordingUrl && (
-            <>
-              <Audio controls>
-                <source src={recordingUrl} type="audio/aac" />
-              </Audio>
-              <Audio controls>
-                <source
-                  src={getUrlWithoutParameters(recordingUrl)}
-                  type="audio/aac"
-                />
-              </Audio>
-              <DownloadClaimFile
-                href={recordingUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Download claim file
-              </DownloadClaimFile>
-              <DownloadClaimFile
-                href={getUrlWithoutParameters(recordingUrl)}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Download claim file
-              </DownloadClaimFile>
-            </>
-          )}
-        </div>
+        <InfoRow>
+          Registered at
+          <InfoText>
+            {registrationDate &&
+              format(parseISO(registrationDate), 'yyyy-MM-dd HH:mm:ss')}
+          </InfoText>
+        </InfoRow>
+        {recordingUrl && <ClaimAudio recordingUrl={recordingUrl} />}
         <SelectWrapper>
           <Label>Status</Label>
           <MuiSelect

--- a/src/components/claims/claim-details/components/ClaimInformation.tsx
+++ b/src/components/claims/claim-details/components/ClaimInformation.tsx
@@ -1,9 +1,5 @@
 import styled from '@emotion/styled'
-import {
-  InputLabel as MuiInputLabel,
-  MenuItem as MuiMenuItem,
-  Select as MuiSelect,
-} from '@material-ui/core'
+import { MenuItem as MuiMenuItem, Select as MuiSelect } from '@material-ui/core'
 import { ClaimState, useClaimInformationQuery } from 'api/generated/graphql'
 
 import { Paper } from 'components/shared/Paper'
@@ -22,7 +18,7 @@ import {
 } from 'graphql/use-update-claim-state'
 import { InfoRow, InfoText } from 'hedvig-ui/info-row'
 import { Loadable } from 'hedvig-ui/loadable'
-import { ErrorText, Paragraph } from 'hedvig-ui/typography'
+import { ErrorText, Label, Paragraph } from 'hedvig-ui/typography'
 import React from 'react'
 import { currentAgreementForContract } from 'utils/contract'
 import { sleep } from 'utils/sleep'
@@ -135,7 +131,7 @@ export const ClaimInformation: React.FC<Props> = ({ claimId, memberId }) => {
           )}
         </div>
         <SelectWrapper>
-          <MuiInputLabel shrink>Status</MuiInputLabel>
+          <Label>Status</Label>
           <MuiSelect
             value={state}
             onChange={async (event) => {
@@ -152,7 +148,7 @@ export const ClaimInformation: React.FC<Props> = ({ claimId, memberId }) => {
           </MuiSelect>
         </SelectWrapper>
         <SelectWrapper>
-          <MuiInputLabel shrink>Employee Claim</MuiInputLabel>
+          <Label>Employee Claim</Label>
           <MuiSelect
             value={coveringEmployee ? 'True' : 'False'}
             onChange={async (event) => {
@@ -174,9 +170,7 @@ export const ClaimInformation: React.FC<Props> = ({ claimId, memberId }) => {
         </SelectWrapper>
         {contracts && (
           <SelectWrapper>
-            <MuiInputLabel shrink error={!selectedContract}>
-              Contract for Claim
-            </MuiInputLabel>
+            <Label>Contract for Claim</Label>
 
             <MuiSelect
               value={selectedContract?.id ? selectedContract.id : 'none'}

--- a/src/components/claims/claim-details/components/ClaimType.tsx
+++ b/src/components/claims/claim-details/components/ClaimType.tsx
@@ -15,7 +15,7 @@ import { Field, Form, Formik } from 'formik'
 import { FormikDateTimePicker } from 'hedvig-ui/date-time-picker'
 import { Loadable } from 'hedvig-ui/loadable'
 import { Spinner } from 'hedvig-ui/sipnner'
-import { ErrorText, Paragraph } from 'hedvig-ui/typography'
+import { ErrorText, Paragraph, ThirdLevelHeadline } from 'hedvig-ui/typography'
 import React from 'react'
 import { WithShowNotification } from 'store/actions/notificationsActions'
 import { withShowNotification } from 'utils/notifications'
@@ -122,7 +122,7 @@ const ClaimTypeComponent: React.FC<ClaimTypeProps & WithShowNotification> = ({
 
   return (
     <Paper>
-      <h3>Type</h3>
+      <ThirdLevelHeadline>Claim Type</ThirdLevelHeadline>
 
       {queryError && <ErrorText>{queryError.message}</ErrorText>}
 


### PR DESCRIPTION
## What?
- Remove the double audio in Claim Information
- Add "Download button" next to audio
- Add a Label to hedvig-ui

## Why?
- Don't know why we try to stream an unsigned s3 link (which seemingly never work), so let's skip that (unless I'm missing something obvious here??)

## Optional screenshots

### Before
![image](https://user-images.githubusercontent.com/51323202/118655805-2e2f1580-b7ea-11eb-91e1-e96b364c4810.png)

### After
![image](https://user-images.githubusercontent.com/51323202/118655835-371fe700-b7ea-11eb-9921-f4a3f006734c.png)


## Optional checklist
- [ ] Updated `src/changelog.ts`
- [x] Codescouted
- [ ] Unit tests written
- [x] Tested locally

