### PR TITLE
Feat/limit member charge

### DIFF
--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -13,6 +13,12 @@ export interface Change {
 export const changelog: ReadonlyArray<Change> = [
   {
     date: '2021-05-26',
+    change:
+      "Limit the direct charge amount to only allow it to match the member's current balance",
+    authorGithubHandle: 'fredriklagerblad',
+  },
+  {
+    date: '2021-05-26',
     change: 'Send chat messages via Cmd-Enter',
     authorGithubHandle: 'vonElfvin',
   },

--- a/src/components/member/tabs/payments-tab/index.tsx
+++ b/src/components/member/tabs/payments-tab/index.tsx
@@ -166,7 +166,7 @@ const PaymentsTabComponent: React.FC<WithShowNotification & {
     )
   }
 
-  if (loading || !data?.member) {
+  if (loading || !data?.member || !account) {
     return <LoadingMessage paddingTop="10vh" />
   }
 
@@ -185,24 +185,31 @@ const PaymentsTabComponent: React.FC<WithShowNotification & {
         <GenerateSetupDirectDebitLink memberId={memberId} />
       </Spacing>
 
-      {data.member?.directDebitStatus?.activated &&
-        Number(account?.currentBalance.amount) > 0.0 && (
-          <Mutation mutation={CHARGE_MEMBER_MUTATION}>
-            {(chargeMember) => (
-              <>
-                <ThirdLevelHeadline>
-                  Charge member's current balance:
-                </ThirdLevelHeadline>
-                <Button
-                  variation="primary"
-                  onClick={() => handleChargeSubmit(chargeMember)}
-                >
-                  Charge {formatMoney(account?.currentBalance!)}
-                </Button>
-              </>
-            )}
-          </Mutation>
-        )}
+      {data.member?.directDebitStatus?.activated && (
+        <>
+          <ThirdLevelHeadline>
+            Charge member's current balance:
+          </ThirdLevelHeadline>
+          {Number(account.currentBalance.amount) > 0.0 ? (
+            <Mutation mutation={CHARGE_MEMBER_MUTATION}>
+              {(chargeMember) => (
+                <>
+                  <Button
+                    variation="primary"
+                    onClick={() => handleChargeSubmit(chargeMember)}
+                  >
+                    Charge {formatMoney(account.currentBalance!)}
+                  </Button>
+                </>
+              )}
+            </Mutation>
+          ) : (
+            `Unable to charge member since the balance is ${formatMoney(
+              account.currentBalance!,
+            )}`
+          )}
+        </>
+      )}
       <br />
       {data.member.payoutMethodStatus?.activated &&
         data.member.contractMarketInfo?.market === Market.Sweden && (

--- a/src/components/member/tabs/payments-tab/index.tsx
+++ b/src/components/member/tabs/payments-tab/index.tsx
@@ -10,15 +10,15 @@ import {
 } from 'components/payouts/payout-details'
 import { format, parseISO } from 'date-fns'
 import gql from 'graphql-tag'
+import { useGetAccount } from 'graphql/use-get-account'
 import {
   LoadingMessage,
   StandaloneMessage,
 } from 'hedvig-ui/animations/standalone-message'
 import { Button } from 'hedvig-ui/button'
-import { Input } from 'hedvig-ui/input'
 import { Spacing } from 'hedvig-ui/spacing'
 import { ThirdLevelHeadline } from 'hedvig-ui/typography'
-import React, { useState } from 'react'
+import React from 'react'
 import { Table } from 'semantic-ui-react'
 import { WithShowNotification } from 'store/actions/notificationsActions'
 import { Market } from 'types/enums'
@@ -26,7 +26,6 @@ import { formatMoney } from 'utils/money'
 import { withShowNotification } from 'utils/notifications'
 import { Checkmark, Cross } from '../../../icons'
 import { GenerateSetupDirectDebitLink } from './generate-setup-direct-debit-link'
-import { useGetAccount } from 'graphql/use-get-account'
 
 const transactionDateSorter = (a, b) => {
   const aDate = new Date(a.timestamp)

--- a/src/components/member/tabs/payments-tab/index.tsx
+++ b/src/components/member/tabs/payments-tab/index.tsx
@@ -191,7 +191,7 @@ const PaymentsTabComponent: React.FC<WithShowNotification & {
             {(chargeMember) => (
               <>
                 <ThirdLevelHeadline>
-                  Charge member's current calance:
+                  Charge member's current balance:
                 </ThirdLevelHeadline>
                 <Button
                   variation="primary"


### PR DESCRIPTION
# Jira Issue: [IPC102]

## What?
- Replace the "free charge amount text field" with a button, that has a hardcoded charge amount, equal to the current balance of the member.

## Why?
- It should not be possible to charge a member anything else but the current balance

## Optional screenshots

## Optional checklist
- [x] Updated `src/changelog.ts`
- [ ] Codescouted
- [ ] Unit tests written
- [x] Tested locally

