### PR TITLE
Ipc 180 add islocked info to contract

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -14042,11 +14042,7 @@
       {
         "name": "skip",
         "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
         "args": [
           {
             "name": "if",
@@ -14067,11 +14063,7 @@
       {
         "name": "include",
         "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
         "args": [
           {
             "name": "if",
@@ -14092,10 +14084,7 @@
       {
         "name": "deprecated",
         "description": "Marks an element of a GraphQL schema as no longer supported.",
-        "locations": [
-          "FIELD_DEFINITION",
-          "ENUM_VALUE"
-        ],
+        "locations": ["FIELD_DEFINITION", "ENUM_VALUE"],
         "args": [
           {
             "name": "reason",

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -2991,6 +2991,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "isLocked",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -14026,7 +14042,11 @@
       {
         "name": "skip",
         "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
-        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+        "locations": [
+          "FIELD",
+          "FRAGMENT_SPREAD",
+          "INLINE_FRAGMENT"
+        ],
         "args": [
           {
             "name": "if",
@@ -14047,7 +14067,11 @@
       {
         "name": "include",
         "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
-        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+        "locations": [
+          "FIELD",
+          "FRAGMENT_SPREAD",
+          "INLINE_FRAGMENT"
+        ],
         "args": [
           {
             "name": "if",
@@ -14068,7 +14092,10 @@
       {
         "name": "deprecated",
         "description": "Marks an element of a GraphQL schema as no longer supported.",
-        "locations": ["FIELD_DEFINITION", "ENUM_VALUE"],
+        "locations": [
+          "FIELD_DEFINITION",
+          "ENUM_VALUE"
+        ],
         "args": [
           {
             "name": "reason",

--- a/schema.graphql
+++ b/schema.graphql
@@ -104,6 +104,7 @@ type MutationType {
     bypassUnderwritingGuidelines: Boolean!
   ): Quote!
   signQuoteForNewContract(quoteId: ID!, activationDate: LocalDate): Quote!
+  overrideQuotePrice(input: OverrideQuotePriceInput!): Quote!
   upsertItemCompany(request: UpsertItemCompanyInput): ID!
   upsertItemType(request: UpsertItemTypeInput): ID!
   upsertItemBrand(request: UpsertItemBrandInput): ID!
@@ -284,6 +285,11 @@ input UpsertValuationRuleInput {
   depreciation: Float
 }
 
+input OverrideQuotePriceInput {
+  quoteId: ID!
+  price: BigDecimal!
+}
+
 type Contract {
   id: ID!
   holderMemberId: ID!
@@ -305,6 +311,7 @@ type Contract {
   signSource: SignSource
   contractTypeName: String!
   createdAt: Instant!
+  isLocked: Boolean!
 }
 
 enum ContractStatus {
@@ -1334,3 +1341,5 @@ scalar Instant
 scalar URL
 # A Json Object represtation of `JsonNode`
 scalar JSON
+
+scalar BigDecimal

--- a/shared/hedvig-ui/card.tsx
+++ b/shared/hedvig-ui/card.tsx
@@ -38,7 +38,6 @@ export interface CardProps {
   span?: number
   padding?: PaddingSize
   locked?: boolean
-  to?: string
   children: any
 }
 
@@ -59,20 +58,17 @@ const CardContainer = styled.div<CardProps>`
 
 export const CardLink = CardContainer.withComponent(Link)
 
-export const Card = ({ children, locked, to, ...cardProps }: CardProps) => {
-  const CardComponent = to ? CardLink : CardContainer
-  return (
-    <CardComponent to={to ?? ''} {...cardProps}>
-      {children}
-      {locked && (
-        <LockedOverlay>
-          Locked
-          <LockFill />
-        </LockedOverlay>
-      )}
-    </CardComponent>
-  )
-}
+export const Card = ({ children, locked, to, ...cardProps }: CardProps) => (
+  <CardContainer {...cardProps}>
+    {children}
+    {locked && (
+      <LockedOverlay>
+        Locked
+        <LockFill />
+      </LockedOverlay>
+    )}
+  </CardContainer>
+)
 
 export const DangerCard = styled(Card)<CardProps>`
   background-color: ${({ theme }) => theme.danger ?? colorsV3.white};

--- a/shared/hedvig-ui/card.tsx
+++ b/shared/hedvig-ui/card.tsx
@@ -58,7 +58,7 @@ const CardContainer = styled.div<CardProps>`
 
 export const CardLink = CardContainer.withComponent(Link)
 
-export const Card = ({ children, locked, to, ...cardProps }: CardProps) => (
+export const Card = ({ children, locked, ...cardProps }: CardProps) => (
   <CardContainer {...cardProps}>
     {children}
     {locked && (

--- a/shared/hedvig-ui/card.tsx
+++ b/shared/hedvig-ui/card.tsx
@@ -1,5 +1,8 @@
 import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
+import React from 'react'
+import { LockFill } from 'react-bootstrap-icons'
+import { Link } from 'react-router-dom'
 
 export const CardsWrapper = styled.div<{ contentWrap?: string }>`
   width: calc(100% + 1rem);
@@ -7,6 +10,20 @@ export const CardsWrapper = styled.div<{ contentWrap?: string }>`
   flex-direction: row;
   flex-wrap: ${({ contentWrap = 'wrap' }) => contentWrap};
   margin: 0rem -0.5rem;
+`
+
+const LockedOverlay = styled.div`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: rgb(255 255 255 / 70%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  font-size: 1.5rem;
 `
 
 type PaddingSize = 'none' | 'small' | 'medium' | 'large'
@@ -17,13 +34,15 @@ export const paddingMap: Record<PaddingSize, string> = {
   medium: '2rem',
   large: '3rem',
 }
-
 export interface CardProps {
   span?: number
   padding?: PaddingSize
+  locked?: boolean
+  to?: string
+  children: any
 }
 
-export const Card = styled('div')<CardProps>`
+const CardContainer = styled.div<CardProps>`
   display: inline-flex;
   min-width: ${({ span }) => `calc(100%/${span ?? 1} - 1rem)`};
   margin: 0.5rem;
@@ -35,7 +54,25 @@ export const Card = styled('div')<CardProps>`
   background-color: ${({ theme }) => theme.accentLighter ?? colorsV3.white};
   border: 1px solid ${({ theme }) => theme.border ?? colorsV3.gray300};
   border-radius: 0.5rem;
+  position: relative;
 `
+
+export const CardLink = CardContainer.withComponent(Link)
+
+export const Card = ({ children, locked, to, ...cardProps }: CardProps) => {
+  const CardComponent = to ? CardLink : CardContainer
+  return (
+    <CardComponent to={to ?? ''} {...cardProps}>
+      {children}
+      {locked && (
+        <LockedOverlay>
+          Locked
+          <LockFill />
+        </LockedOverlay>
+      )}
+    </CardComponent>
+  )
+}
 
 export const DangerCard = styled(Card)<CardProps>`
   background-color: ${({ theme }) => theme.danger ?? colorsV3.white};

--- a/src/api/generated/graphql.tsx
+++ b/src/api/generated/graphql.tsx
@@ -434,7 +434,7 @@ export type Contract = {
   signSource?: Maybe<SignSource>
   contractTypeName: Scalars['String']
   createdAt: Scalars['Instant']
-  isLocked?: Scalars['Boolean']
+  isLocked: Scalars['Boolean']
 }
 
 export type ContractMarketInfo = {
@@ -2857,6 +2857,7 @@ export type GetContractsQuery = { __typename?: 'QueryType' } & {
             | 'typeOfContract'
             | 'contractTypeName'
             | 'createdAt'
+            | 'isLocked'
           > & {
               genericAgreements: Array<
                 { __typename?: 'GenericAgreement' } & Pick<
@@ -7025,6 +7026,7 @@ export const GetContractsDocument = gql`
         typeOfContract
         contractTypeName
         createdAt
+        isLocked
       }
     }
   }

--- a/src/api/generated/graphql.tsx
+++ b/src/api/generated/graphql.tsx
@@ -433,6 +433,7 @@ export type Contract = {
   signSource?: Maybe<SignSource>
   contractTypeName: Scalars['String']
   createdAt: Scalars['Instant']
+  isLocked?: Scalars['Boolean']
 }
 
 export type ContractMarketInfo = {

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -12,6 +12,11 @@ export interface Change {
 
 export const changelog: ReadonlyArray<Change> = [
   {
+    date: '2021-07-09',
+    change: 'Locked contracts can no longer be interacted with',
+    authorGithubHandle: 'joacimastrom',
+  },
+  {
     date: '2021-07-06',
     change: 'Allow quote price to be overridden manually',
     authorGithubHandle: 'joacimastrom',

--- a/src/components/member/tabs/contracts-tab/agreement/AgreementsTable.tsx
+++ b/src/components/member/tabs/contracts-tab/agreement/AgreementsTable.tsx
@@ -47,7 +47,6 @@ export const AgreementsTable: React.FC<{
           const isSelected = agreement.id === selectedAgreement
           return (
             <SelectableTableRow
-              singleLine
               key={agreement.id}
               onClick={() =>
                 selectedAgreement === agreement.id

--- a/src/components/member/tabs/contracts-tab/contract/index.tsx
+++ b/src/components/member/tabs/contracts-tab/contract/index.tsx
@@ -8,6 +8,7 @@ import { Card, CardsWrapper } from 'hedvig-ui/card'
 import { InfoContainer, InfoRow, InfoText } from 'hedvig-ui/info-row'
 import { ThirdLevelHeadline } from 'hedvig-ui/typography'
 import React from 'react'
+import { LockFill } from 'react-bootstrap-icons'
 import { getSignSource } from 'utils/contract'
 import { convertEnumToTitle } from 'utils/text'
 
@@ -38,7 +39,10 @@ export const Contract: React.FC<{
         <Card span={3}>
           <InfoContainer>
             <ThirdLevelHeadline>
-              <InfoRow>{contract.contractTypeName}</InfoRow>
+              <InfoRow>
+                {contract.contractTypeName}
+                {!contract.isLocked && <LockFill />}
+              </InfoRow>
             </ThirdLevelHeadline>
             <InfoRow>
               Holder{' '}
@@ -63,11 +67,25 @@ export const Contract: React.FC<{
           </InfoContainer>
         </Card>
         <Card span={3}>
-          <ThirdLevelHeadline>Master Inception</ThirdLevelHeadline>
+          <InfoContainer>
+            <ThirdLevelHeadline>
+              <InfoRow>
+                Master Inception
+                {!contract.isLocked && <LockFill />}
+              </InfoRow>
+            </ThirdLevelHeadline>
+          </InfoContainer>
           <MasterInception contract={contract} />
         </Card>
         <Card span={3}>
-          <ThirdLevelHeadline>Termination Date</ThirdLevelHeadline>
+          <InfoContainer>
+            <ThirdLevelHeadline>
+              <InfoRow>
+                Termination Date
+                {!contract.isLocked && <LockFill />}
+              </InfoRow>
+            </ThirdLevelHeadline>
+          </InfoContainer>
           <TerminationDate contract={contract} />
         </Card>
       </CardsWrapper>

--- a/src/components/member/tabs/contracts-tab/contract/index.tsx
+++ b/src/components/member/tabs/contracts-tab/contract/index.tsx
@@ -20,6 +20,32 @@ const ContractWrapper = styled('div')`
   }
 `
 
+const LockedOverlay = styled('div')`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: rgb(255 255 255 / 70%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  font-size: 1.5rem;
+`
+
+const ContractCard = ({ locked, children, ...cardProps }) => (
+  <Card {...cardProps} style={{ position: 'relative' }}>
+    {children}
+    {locked && (
+      <LockedOverlay>
+        Locked
+        <LockFill />
+      </LockedOverlay>
+    )}
+  </Card>
+)
+
 export const Contract: React.FC<{
   contract: ContractType
   refetch: () => Promise<any>
@@ -36,13 +62,14 @@ export const Contract: React.FC<{
   return (
     <ContractWrapper>
       <CardsWrapper>
-        <Card span={3}>
+        <ContractCard
+          locked={!contract.isLocked}
+          style={{ position: 'relative' }}
+          span={3}
+        >
           <InfoContainer>
             <ThirdLevelHeadline>
-              <InfoRow>
-                {contract.contractTypeName}
-                {!contract.isLocked && <LockFill />}
-              </InfoRow>
+              <InfoRow>{contract.contractTypeName}</InfoRow>
             </ThirdLevelHeadline>
             <InfoRow>
               Holder{' '}
@@ -65,7 +92,7 @@ export const Contract: React.FC<{
               </InfoRow>
             )}
           </InfoContainer>
-        </Card>
+        </ContractCard>
         <Card span={3}>
           <InfoContainer>
             <ThirdLevelHeadline>

--- a/src/components/member/tabs/contracts-tab/contract/index.tsx
+++ b/src/components/member/tabs/contracts-tab/contract/index.tsx
@@ -8,7 +8,6 @@ import { Card, CardsWrapper } from 'hedvig-ui/card'
 import { InfoContainer, InfoRow, InfoText } from 'hedvig-ui/info-row'
 import { ThirdLevelHeadline } from 'hedvig-ui/typography'
 import React from 'react'
-import { LockFill } from 'react-bootstrap-icons'
 import { getSignSource } from 'utils/contract'
 import { convertEnumToTitle } from 'utils/text'
 
@@ -19,32 +18,6 @@ const ContractWrapper = styled('div')`
     padding-top: 5rem;
   }
 `
-
-const LockedOverlay = styled('div')`
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  background-color: rgb(255 255 255 / 70%);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100%;
-  font-size: 1.5rem;
-`
-
-const ContractCard = ({ locked, children, ...cardProps }) => (
-  <Card {...cardProps} style={{ position: 'relative' }}>
-    {children}
-    {locked && (
-      <LockedOverlay>
-        Locked
-        <LockFill />
-      </LockedOverlay>
-    )}
-  </Card>
-)
 
 export const Contract: React.FC<{
   contract: ContractType
@@ -62,11 +35,7 @@ export const Contract: React.FC<{
   return (
     <ContractWrapper>
       <CardsWrapper>
-        <ContractCard
-          locked={!contract.isLocked}
-          style={{ position: 'relative' }}
-          span={3}
-        >
+        <Card locked={contract.isLocked} span={3}>
           <InfoContainer>
             <ThirdLevelHeadline>
               <InfoRow>{contract.contractTypeName}</InfoRow>
@@ -92,27 +61,13 @@ export const Contract: React.FC<{
               </InfoRow>
             )}
           </InfoContainer>
-        </ContractCard>
-        <Card span={3}>
-          <InfoContainer>
-            <ThirdLevelHeadline>
-              <InfoRow>
-                Master Inception
-                {!contract.isLocked && <LockFill />}
-              </InfoRow>
-            </ThirdLevelHeadline>
-          </InfoContainer>
+        </Card>
+        <Card locked={contract.isLocked} span={3}>
+          <ThirdLevelHeadline>Master Inception</ThirdLevelHeadline>
           <MasterInception contract={contract} />
         </Card>
-        <Card span={3}>
-          <InfoContainer>
-            <ThirdLevelHeadline>
-              <InfoRow>
-                Termination Date
-                {!contract.isLocked && <LockFill />}
-              </InfoRow>
-            </ThirdLevelHeadline>
-          </InfoContainer>
+        <Card locked={contract.isLocked} span={3}>
+          <ThirdLevelHeadline>Termination Date</ThirdLevelHeadline>
           <TerminationDate contract={contract} />
         </Card>
       </CardsWrapper>

--- a/src/components/member/tabs/contracts-tab/contract/index.tsx
+++ b/src/components/member/tabs/contracts-tab/contract/index.tsx
@@ -37,11 +37,9 @@ export const Contract: React.FC<{
       <CardsWrapper>
         <Card span={3}>
           <InfoContainer>
-            <InfoRow>
-              <ThirdLevelHeadline>
-                {contract.contractTypeName}
-              </ThirdLevelHeadline>
-            </InfoRow>
+            <ThirdLevelHeadline>
+              <InfoRow>{contract.contractTypeName}</InfoRow>
+            </ThirdLevelHeadline>
             <InfoRow>
               Holder{' '}
               <InfoText>

--- a/src/components/member/tabs/contracts-tab/contract/termination-date.tsx
+++ b/src/components/member/tabs/contracts-tab/contract/termination-date.tsx
@@ -19,6 +19,7 @@ import { Spacing } from 'hedvig-ui/spacing'
 import { TextArea } from 'hedvig-ui/text-area'
 import { FourthLevelHeadline } from 'hedvig-ui/typography'
 import React from 'react'
+import { LockFill } from 'react-bootstrap-icons'
 import { WithShowNotification } from 'store/actions/notificationsActions'
 import { withShowNotification } from 'utils/notifications'
 
@@ -65,45 +66,47 @@ const TerminationDateComponent: React.FC<{
                 {contract.terminationDate}
               </FourthLevelHeadline>
             </Spacing>
-            <ButtonsGroup>
-              <Button
-                fullWidth
-                variation={'secondary'}
-                onClick={() => setDatePickerEnabled(true)}
-              >
-                Change
-              </Button>
-              <Button
-                fullWidth
-                variation={'success'}
-                disabled={revertTerminationLoading}
-                onClick={() => {
-                  if (
-                    window.confirm('Are you want to revert the termination?')
-                  ) {
-                    revertTermination(revertTerminationOptions(contract))
-                      .then(() => {
-                        showNotification({
-                          type: 'olive',
-                          header: 'Termination reverted',
-                          message: 'Successfully reverted the termination',
+            {contract.isLocked && (
+              <ButtonsGroup>
+                <Button
+                  fullWidth
+                  variation={'secondary'}
+                  onClick={() => setDatePickerEnabled(true)}
+                >
+                  Change
+                </Button>
+                <Button
+                  fullWidth
+                  variation={'success'}
+                  disabled={revertTerminationLoading}
+                  onClick={() => {
+                    if (
+                      window.confirm('Are you want to revert the termination?')
+                    ) {
+                      revertTermination(revertTerminationOptions(contract))
+                        .then(() => {
+                          showNotification({
+                            type: 'olive',
+                            header: 'Termination reverted',
+                            message: 'Successfully reverted the termination',
+                          })
+                          reset()
                         })
-                        reset()
-                      })
-                      .catch((error) => {
-                        showNotification({
-                          type: 'red',
-                          header: 'Unable to revert termination',
-                          message: error.message,
+                        .catch((error) => {
+                          showNotification({
+                            type: 'red',
+                            header: 'Unable to revert termination',
+                            message: error.message,
+                          })
+                          throw error
                         })
-                        throw error
-                      })
-                  }
-                }}
-              >
-                Revert
-              </Button>
-            </ButtonsGroup>
+                    }
+                  }}
+                >
+                  Revert
+                </Button>
+              </ButtonsGroup>
+            )}
           </>
         )}
         {datePickerEnabled && (

--- a/src/components/member/tabs/contracts-tab/contract/termination-date.tsx
+++ b/src/components/member/tabs/contracts-tab/contract/termination-date.tsx
@@ -19,7 +19,6 @@ import { Spacing } from 'hedvig-ui/spacing'
 import { TextArea } from 'hedvig-ui/text-area'
 import { FourthLevelHeadline } from 'hedvig-ui/typography'
 import React from 'react'
-import { LockFill } from 'react-bootstrap-icons'
 import { WithShowNotification } from 'store/actions/notificationsActions'
 import { withShowNotification } from 'utils/notifications'
 
@@ -66,47 +65,45 @@ const TerminationDateComponent: React.FC<{
                 {contract.terminationDate}
               </FourthLevelHeadline>
             </Spacing>
-            {contract.isLocked && (
-              <ButtonsGroup>
-                <Button
-                  fullWidth
-                  variation={'secondary'}
-                  onClick={() => setDatePickerEnabled(true)}
-                >
-                  Change
-                </Button>
-                <Button
-                  fullWidth
-                  variation={'success'}
-                  disabled={revertTerminationLoading}
-                  onClick={() => {
-                    if (
-                      window.confirm('Are you want to revert the termination?')
-                    ) {
-                      revertTermination(revertTerminationOptions(contract))
-                        .then(() => {
-                          showNotification({
-                            type: 'olive',
-                            header: 'Termination reverted',
-                            message: 'Successfully reverted the termination',
-                          })
-                          reset()
+            <ButtonsGroup>
+              <Button
+                fullWidth
+                variation={'secondary'}
+                onClick={() => setDatePickerEnabled(true)}
+              >
+                Change
+              </Button>
+              <Button
+                fullWidth
+                variation={'success'}
+                disabled={revertTerminationLoading}
+                onClick={() => {
+                  if (
+                    window.confirm('Are you want to revert the termination?')
+                  ) {
+                    revertTermination(revertTerminationOptions(contract))
+                      .then(() => {
+                        showNotification({
+                          type: 'olive',
+                          header: 'Termination reverted',
+                          message: 'Successfully reverted the termination',
                         })
-                        .catch((error) => {
-                          showNotification({
-                            type: 'red',
-                            header: 'Unable to revert termination',
-                            message: error.message,
-                          })
-                          throw error
+                        reset()
+                      })
+                      .catch((error) => {
+                        showNotification({
+                          type: 'red',
+                          header: 'Unable to revert termination',
+                          message: error.message,
                         })
-                    }
-                  }}
-                >
-                  Revert
-                </Button>
-              </ButtonsGroup>
-            )}
+                        throw error
+                      })
+                  }
+                }}
+              >
+                Revert
+              </Button>
+            </ButtonsGroup>
           </>
         )}
         {datePickerEnabled && (

--- a/src/components/member/tabs/contracts-tab/index.tsx
+++ b/src/components/member/tabs/contracts-tab/index.tsx
@@ -38,7 +38,7 @@ export const ContractTab: React.FC<{
           Contracts
           <RefreshButton
             onClick={() => refetch()}
-            loading={loading ? true : undefined}
+            loading={loading || undefined}
           >
             <ArrowRepeat />
           </RefreshButton>

--- a/src/components/member/tabs/contracts-tab/index.tsx
+++ b/src/components/member/tabs/contracts-tab/index.tsx
@@ -36,7 +36,10 @@ export const ContractTab: React.FC<{
       {contracts.length > 0 && (
         <MainHeadline>
           Contracts
-          <RefreshButton onClick={() => refetch()} loading={loading}>
+          <RefreshButton
+            onClick={() => refetch()}
+            loading={loading ? true : undefined}
+          >
             <ArrowRepeat />
           </RefreshButton>
         </MainHeadline>

--- a/src/components/member/tabs/shared/refresh-button.tsx
+++ b/src/components/member/tabs/shared/refresh-button.tsx
@@ -5,7 +5,7 @@ const spin = keyframes`
   from{transform: rotate(0deg)}
   to{transform: rotate(360deg)}
 `
-export const RefreshButton = styled.button<{ loading: boolean }>`
+export const RefreshButton = styled.button<{ loading?: boolean }>`
   background: transparent;
   font-size: 0.875em;
   color: ${({ theme }) => theme.mutedText};

--- a/src/features/tools/index.tsx
+++ b/src/features/tools/index.tsx
@@ -4,7 +4,7 @@ import {
   stagingToolsAvailable,
 } from 'features/tools/staging-tools'
 import { FadeIn } from 'hedvig-ui/animations/fade-in'
-import { CardLink, CardsWrapper } from 'hedvig-ui/card'
+import { Card, CardsWrapper } from 'hedvig-ui/card'
 import React from 'react'
 
 const Icon = styled('div')`
@@ -15,31 +15,32 @@ const Icon = styled('div')`
 export const Tools: React.FC = () => (
   <FadeIn>
     <CardsWrapper>
-      <CardLink to="/tools/charges" span={4}>
+      <Card to="/tools/charges" span={4}>
         <Icon>💰</Icon>
         Approve Charges
-      </CardLink>
-      <CardLink to="/tools/switcher-automation" span={4}>
+      </Card>
+      <Card to="/tools/switcher-automation" span={4}>
         <Icon>🏡</Icon>
         Switcher Automation
-      </CardLink>
-      <CardLink to="/tools/perils-editor" span={4}>
+      </Card>
+      <Card to="/tools/perils-editor" span={4}>
         <Icon>📝</Icon>
         Perils Editor
-      </CardLink>
-      <CardLink to="/tools/norwegian-tariff-creator" span={4}>
+      </Card>
+      <Card to="/tools/norwegian-tariff-creator" span={4}>
         <Icon>🛩</Icon>
         Norwegian Price Engine "Gripen"
-      </CardLink>
-      <CardLink to="/tools/campaign-codes" span={4}>
+      </Card>
+      <Card to="/tools/campaign-codes" span={4}>
         <Icon>💵</Icon>
         Campaign Codes
-      </CardLink>
-      <CardLink to="/tools/itemizer" span={4}>
+      </Card>
+      <Card to="/tools/itemizer" span={4}>
         <Icon>📱</Icon>
         Itemizer
-      </CardLink>
+      </Card>
     </CardsWrapper>
+
     {stagingToolsAvailable() && <StagingTools />}
   </FadeIn>
 )

--- a/src/features/tools/index.tsx
+++ b/src/features/tools/index.tsx
@@ -4,16 +4,13 @@ import {
   stagingToolsAvailable,
 } from 'features/tools/staging-tools'
 import { FadeIn } from 'hedvig-ui/animations/fade-in'
-import { Card, CardsWrapper } from 'hedvig-ui/card'
+import { CardLink, CardsWrapper } from 'hedvig-ui/card'
 import React from 'react'
-import { Link } from 'react-router-dom'
 
 const Icon = styled('div')`
   font-size: 2rem;
   padding-bottom: 1rem;
 `
-
-export const CardLink = Card.withComponent(Link)
 
 export const Tools: React.FC = () => (
   <FadeIn>
@@ -22,33 +19,27 @@ export const Tools: React.FC = () => (
         <Icon>💰</Icon>
         Approve Charges
       </CardLink>
-
       <CardLink to="/tools/switcher-automation" span={4}>
         <Icon>🏡</Icon>
         Switcher Automation
       </CardLink>
-
       <CardLink to="/tools/perils-editor" span={4}>
         <Icon>📝</Icon>
         Perils Editor
       </CardLink>
-
       <CardLink to="/tools/norwegian-tariff-creator" span={4}>
         <Icon>🛩</Icon>
         Norwegian Price Engine "Gripen"
       </CardLink>
-
       <CardLink to="/tools/campaign-codes" span={4}>
         <Icon>💵</Icon>
         Campaign Codes
       </CardLink>
-
       <CardLink to="/tools/itemizer" span={4}>
         <Icon>📱</Icon>
         Itemizer
       </CardLink>
     </CardsWrapper>
-
     {stagingToolsAvailable() && <StagingTools />}
   </FadeIn>
 )

--- a/src/features/tools/index.tsx
+++ b/src/features/tools/index.tsx
@@ -4,7 +4,7 @@ import {
   stagingToolsAvailable,
 } from 'features/tools/staging-tools'
 import { FadeIn } from 'hedvig-ui/animations/fade-in'
-import { Card, CardsWrapper } from 'hedvig-ui/card'
+import { CardLink, CardsWrapper } from 'hedvig-ui/card'
 import React from 'react'
 
 const Icon = styled('div')`
@@ -15,30 +15,30 @@ const Icon = styled('div')`
 export const Tools: React.FC = () => (
   <FadeIn>
     <CardsWrapper>
-      <Card to="/tools/charges" span={4}>
+      <CardLink to="/tools/charges" span={4}>
         <Icon>💰</Icon>
         Approve Charges
-      </Card>
-      <Card to="/tools/switcher-automation" span={4}>
+      </CardLink>
+      <CardLink to="/tools/switcher-automation" span={4}>
         <Icon>🏡</Icon>
         Switcher Automation
-      </Card>
-      <Card to="/tools/perils-editor" span={4}>
+      </CardLink>
+      <CardLink to="/tools/perils-editor" span={4}>
         <Icon>📝</Icon>
         Perils Editor
-      </Card>
-      <Card to="/tools/norwegian-tariff-creator" span={4}>
+      </CardLink>
+      <CardLink to="/tools/norwegian-tariff-creator" span={4}>
         <Icon>🛩</Icon>
         Norwegian Price Engine "Gripen"
-      </Card>
-      <Card to="/tools/campaign-codes" span={4}>
+      </CardLink>
+      <CardLink to="/tools/campaign-codes" span={4}>
         <Icon>💵</Icon>
         Campaign Codes
-      </Card>
-      <Card to="/tools/itemizer" span={4}>
+      </CardLink>
+      <CardLink to="/tools/itemizer" span={4}>
         <Icon>📱</Icon>
         Itemizer
-      </Card>
+      </CardLink>
     </CardsWrapper>
 
     {stagingToolsAvailable() && <StagingTools />}

--- a/src/features/tools/staging-tools/index.tsx
+++ b/src/features/tools/staging-tools/index.tsx
@@ -1,8 +1,7 @@
-import { CardLink } from 'features/tools'
-import { CardsWrapper } from 'hedvig-ui/card'
+import styled from '@emotion/styled'
+import { CardLink, CardsWrapper } from 'hedvig-ui/card'
 import { MainHeadline } from 'hedvig-ui/typography'
 import React from 'react'
-import styled from '@emotion/styled'
 
 const Icon = styled('div')`
   font-size: 2rem;

--- a/src/graphql/get-contracts.graphql
+++ b/src/graphql/get-contracts.graphql
@@ -58,6 +58,7 @@ query GetContracts($memberId: ID!) {
       typeOfContract
       contractTypeName
       createdAt
+      isLocked
     }
   }
 }


### PR DESCRIPTION
# Jira Issue: IPC-180

## What?
- Show a user when a contract is locked
- Overlay the contract so it cannot be interacted with
- Make `<Card>` a component that takes a prop `locked`
- Minor cleanup of console errors

## Why?
- There is no user feedback for when a contract is locked
- When a contract is locked, all requests will return errors. This is poor user experience

## Optional screenshots
![image](https://user-images.githubusercontent.com/4789631/125040326-cf727380-e097-11eb-9d98-567ac80d4520.png)

## Optional checklist
- [x] Updated `src/changelog.ts`
- [X] Codescouted
- [ ] Unit tests written
- [X] Tested locally

