### PR TITLE
Disable create quote on locked contracts

### DIFF
--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -12,6 +12,11 @@ export interface Change {
 
 export const changelog: ReadonlyArray<Change> = [
   {
+    date: '2021-08.10',
+    change: 'Disable button to create quotes on locked contracts',
+    authorGithubHandle: 'joacimastrom',
+  },
+  {
     date: '2021-08-05',
     change: 'Allow contract activation and termination in switcher view',
     authorGithubHandle: 'cpiehl1',

--- a/src/components/member/tabs/contracts-tab/agreement/CreateQuoteFromAgreement.tsx
+++ b/src/components/member/tabs/contracts-tab/agreement/CreateQuoteFromAgreement.tsx
@@ -41,6 +41,7 @@ export const CreateQuoteFromAgreement: React.FC<{
           <>Agreement already has an existing quote</>
         ) : (
           <Button
+            disabled={contract.isLocked}
             variation="primary"
             onClick={() => {
               if (!window.confirm(`Create new quote?`)) {


### PR DESCRIPTION
# Jira Issue: [IPC-186]

## What?
- Disable "Create Quote" on locked contracts

## Why?
- Backend will not allow new quotes on blocked contracts, so may as well disable the button

## Optional screenshots
![image](https://user-images.githubusercontent.com/4789631/128850885-6385b32b-dfac-4bed-9ef3-1447d2db1a44.png)


## Optional checklist
- [x] Updated `src/changelog.ts`
- [ ] Codescouted
- [ ] Unit tests written
- [x] Tested locally



[IPC-186]: https://hedvig.atlassian.net/browse/IPC-186