### PR TITLE
Cleaning & killing some material-ui

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -13928,11 +13928,7 @@
       {
         "name": "skip",
         "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
         "args": [
           {
             "name": "if",
@@ -13953,11 +13949,7 @@
       {
         "name": "include",
         "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
         "args": [
           {
             "name": "if",
@@ -13978,10 +13970,7 @@
       {
         "name": "deprecated",
         "description": "Marks an element of a GraphQL schema as no longer supported.",
-        "locations": [
-          "FIELD_DEFINITION",
-          "ENUM_VALUE"
-        ],
+        "locations": ["FIELD_DEFINITION", "ENUM_VALUE"],
         "args": [
           {
             "name": "reason",

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -13928,7 +13928,11 @@
       {
         "name": "skip",
         "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
-        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+        "locations": [
+          "FIELD",
+          "FRAGMENT_SPREAD",
+          "INLINE_FRAGMENT"
+        ],
         "args": [
           {
             "name": "if",
@@ -13949,7 +13953,11 @@
       {
         "name": "include",
         "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
-        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+        "locations": [
+          "FIELD",
+          "FRAGMENT_SPREAD",
+          "INLINE_FRAGMENT"
+        ],
         "args": [
           {
             "name": "if",
@@ -13970,7 +13978,10 @@
       {
         "name": "deprecated",
         "description": "Marks an element of a GraphQL schema as no longer supported.",
-        "locations": ["FIELD_DEFINITION", "ENUM_VALUE"],
+        "locations": [
+          "FIELD_DEFINITION",
+          "ENUM_VALUE"
+        ],
         "args": [
           {
             "name": "reason",

--- a/shared/hedvig-ui/dropdown.stories.tsx
+++ b/shared/hedvig-ui/dropdown.stories.tsx
@@ -20,7 +20,7 @@ export const DropdownWithEnum: React.FC = () => {
       <EnumDropdown
         enumToSelectFrom={Taste}
         placeholder={'Select a taste'}
-        setValue={setTaste}
+        onChange={setTaste}
       />
       <h3>
         <strong>Selected taste:</strong>

--- a/shared/hedvig-ui/dropdown.tsx
+++ b/shared/hedvig-ui/dropdown.tsx
@@ -5,14 +5,14 @@ import {
   DropdownItemProps,
 } from 'semantic-ui-react'
 
-const StyledDropdown = styled(SemanticDropdown)({
-  width: '100%',
-})
+const StyledDropdown = styled(SemanticDropdown)`
+  width: 100%;
+`
 
 interface DropdownValue {
   key?: string
   value: string
-  text: string
+  content: React.ReactElement
 }
 
 export const Dropdown: React.FC<{
@@ -20,10 +20,23 @@ export const Dropdown: React.FC<{
   onChange: (value: string) => void
   value: string
   loading?: boolean
-}> = ({ options, onChange, value, loading, ...props }) => {
+  onRender?: () => React.ReactNode | null
+  emptyLabel?: string
+  className?: string
+}> = ({
+  options,
+  onChange,
+  value,
+  loading,
+  onRender,
+  emptyLabel,
+  className,
+  ...props
+}) => {
   const [autoLoading, setAutoLoading] = useState(false)
-  const getOptions = (): DropdownValue[] =>
-    Object(options).map((option) => {
+
+  const getOptions = (): DropdownValue[] => [
+    ...Object(options).map((option) => {
       if (typeof option === 'string') {
         return {
           key: option + new Date().toString(),
@@ -33,10 +46,12 @@ export const Dropdown: React.FC<{
       }
 
       return option
-    })
+    }),
+  ]
 
   return (
     <StyledDropdown
+      icon={getOptions().length === 0 ? null : undefined}
       value={value}
       loading={loading ?? autoLoading}
       onChange={async (_, { value: selection }) => {
@@ -45,7 +60,10 @@ export const Dropdown: React.FC<{
         setAutoLoading(false)
       }}
       options={getOptions()}
-      selection
+      selectOnBlur={false}
+      selectOnNavigation={false}
+      className={'selection ' + (className ?? '')}
+      trigger={onRender ? onRender() : undefined}
       {...props}
     />
   )

--- a/shared/hedvig-ui/dropdown.tsx
+++ b/shared/hedvig-ui/dropdown.tsx
@@ -19,7 +19,9 @@ export const Dropdown: React.FC<{
   options: DropdownValue[] | string[]
   onChange: (value: string) => void
   value: string
-}> = ({ options, onChange, value, ...props }) => {
+  loading?: boolean
+}> = ({ options, onChange, value, loading, ...props }) => {
+  const [autoLoading, setAutoLoading] = useState(false)
   const getOptions = (): DropdownValue[] =>
     Object(options).map((option) => {
       if (typeof option === 'string') {
@@ -36,7 +38,12 @@ export const Dropdown: React.FC<{
   return (
     <StyledDropdown
       value={value}
-      onChange={(_, { value: selection }) => onChange(selection as string)}
+      loading={loading ?? autoLoading}
+      onChange={async (_, { value: selection }) => {
+        setAutoLoading(true)
+        await onChange(selection as string)
+        setAutoLoading(false)
+      }}
       options={getOptions()}
       selection
       {...props}
@@ -47,10 +54,10 @@ export const Dropdown: React.FC<{
 export const EnumDropdown: React.FC<{
   value?: any
   enumToSelectFrom: any
-  placeholder: string
+  placeholder?: string
   setValue: (value: any) => void
   loading?: boolean
-}> = ({ enumToSelectFrom, placeholder, setValue, value, loading }) => {
+}> = ({ enumToSelectFrom, placeholder = '', setValue, value, loading }) => {
   const [autoLoading, setAutoLoading] = useState(false)
   const dropdownOptions: DropdownItemProps[] = Object.values(
     enumToSelectFrom,

--- a/shared/hedvig-ui/dropdown.tsx
+++ b/shared/hedvig-ui/dropdown.tsx
@@ -1,22 +1,11 @@
-import styled from '@emotion/styled'
-import React, { useState } from 'react'
+import React, { useMemo } from 'react'
 import {
   Dropdown as SemanticDropdown,
   DropdownItemProps,
 } from 'semantic-ui-react'
 
-const StyledDropdown = styled(SemanticDropdown)`
-  width: 100%;
-`
-
-interface DropdownValue {
-  key?: string
-  value: string
-  content: React.ReactElement
-}
-
 export const Dropdown: React.FC<{
-  options: DropdownValue[] | string[]
+  options: DropdownItemProps[]
   onChange: (value: string) => void
   value: string
   loading?: boolean
@@ -33,33 +22,13 @@ export const Dropdown: React.FC<{
   className,
   ...props
 }) => {
-  const [autoLoading, setAutoLoading] = useState(false)
-
-  const getOptions = (): DropdownValue[] => [
-    ...Object(options).map((option) => {
-      if (typeof option === 'string') {
-        return {
-          key: option + new Date().toString(),
-          value: option,
-          text: option,
-        }
-      }
-
-      return option
-    }),
-  ]
-
   return (
-    <StyledDropdown
-      icon={getOptions().length === 0 ? null : undefined}
+    <SemanticDropdown
       value={value}
-      loading={loading ?? autoLoading}
-      onChange={async (_, { value: selection }) => {
-        setAutoLoading(true)
-        await onChange(selection as string)
-        setAutoLoading(false)
-      }}
-      options={getOptions()}
+      loading={loading}
+      onChange={(_, { value: selection }) => onChange(selection as string)}
+      fluid
+      options={options}
       selectOnBlur={false}
       selectOnNavigation={false}
       className={'selection ' + (className ?? '')}
@@ -73,39 +42,37 @@ export const EnumDropdown: React.FC<{
   value?: any
   enumToSelectFrom: any
   placeholder?: string
-  setValue: (value: any) => void
+  onChange: (value: any) => void
   loading?: boolean
-}> = ({ enumToSelectFrom, placeholder = '', setValue, value, loading }) => {
-  const [autoLoading, setAutoLoading] = useState(false)
-  const dropdownOptions: DropdownItemProps[] = Object.values(
-    enumToSelectFrom,
-  ).map((selection, index) => {
-    if (typeof value === 'number') {
-      throw new Error(
-        `EnumDropdown does not support enums with ordinal values (yet), enumToSelectFrom: ${JSON.stringify(
-          enumToSelectFrom,
-        )}`,
-      )
-    }
-    return {
-      key: index + 1,
-      value: selection as string,
-      text: getTextFromEnumValue(selection as string),
-    }
-  })
+}> = ({ enumToSelectFrom, placeholder = '', onChange, value, loading }) => {
+  const dropdownOptions = useMemo(
+    () =>
+      Object.values(enumToSelectFrom).map((selection, index) => {
+        if (typeof value === 'number') {
+          throw new Error(
+            `EnumDropdown does not support enums with ordinal values (yet), enumToSelectFrom: ${JSON.stringify(
+              enumToSelectFrom,
+            )}`,
+          )
+        }
+        return {
+          key: index + 1,
+          value: selection as string,
+          text: getTextFromEnumValue(selection as string),
+        }
+      }),
+    [enumToSelectFrom],
+  )
 
   return (
-    <StyledDropdown
+    <SemanticDropdown
       value={value}
       placeholder={placeholder}
       options={dropdownOptions}
-      loading={loading ?? autoLoading}
+      loading={loading}
       selection
-      onChange={async (_, { value: selection }) => {
-        setAutoLoading(true)
-        await setValue(selection)
-        setAutoLoading(false)
-      }}
+      fluid
+      onChange={(_, { value: selection }) => onChange(selection)}
     />
   )
 }

--- a/shared/hedvig-ui/list.tsx
+++ b/shared/hedvig-ui/list.tsx
@@ -1,0 +1,12 @@
+import styled from '@emotion/styled'
+
+export const List = styled.ul`
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+`
+
+export const ListItem = styled.li`
+  list-style-type: none;
+  margin: 1.5em 0;
+`

--- a/shared/hedvig-ui/list.tsx
+++ b/shared/hedvig-ui/list.tsx
@@ -8,5 +8,16 @@ export const List = styled.ul`
 
 export const ListItem = styled.li`
   list-style-type: none;
-  margin: 1.5em 0;
+  margin: 0;
+  padding: 1em 0;
+  border-bottom: 1px solid ${({ theme }) => theme.backgroundTransparent};
+
+  :first-child {
+    margin-top: 0;
+  }
+
+  :last-child {
+    border: none;
+    margin-bottom: 0;
+  }
 `

--- a/shared/hedvig-ui/list.tsx
+++ b/shared/hedvig-ui/list.tsx
@@ -12,7 +12,7 @@ export const ListItem = styled.li`
   padding: 1em 0;
   border-bottom: 1px solid ${({ theme }) => theme.backgroundTransparent};
 
-  :first-child {
+  :first-of-type {
     margin-top: 0;
   }
 

--- a/shared/hedvig-ui/text-area.stories.tsx
+++ b/shared/hedvig-ui/text-area.stories.tsx
@@ -14,7 +14,7 @@ export const TextAreaThatGrows: React.FC = () => {
       <TextArea
         placeholder={'Write your life story here...'}
         value={text}
-        setValue={setText}
+        onChange={setText}
       />
       <p>
         <strong>Written text:</strong> {text}

--- a/shared/hedvig-ui/text-area.tsx
+++ b/shared/hedvig-ui/text-area.tsx
@@ -2,22 +2,28 @@ import styled from '@emotion/styled'
 import React from 'react'
 import { TextArea as SemanticTextArea } from 'semantic-ui-react'
 
-const TextAreaWrapper = styled('div')({
-  width: '100%',
-})
+const TextAreaWrapper = styled.div`
+  width: 100%;
+`
+
+const StyledSemanticTextArea = styled(SemanticTextArea)`
+  min-height: 3em;
+  overflow: hidden;
+  resize: none;
+  height: 100%;
+`
 
 export const TextArea: React.FC<{
   placeholder: string
   value: string | undefined
-  setValue: (value: string) => void
-}> = ({ placeholder, value: inputValue, setValue: setInputValue }) => {
+  onChange: (value: string) => void
+}> = ({ placeholder, value: inputValue, onChange }) => {
   return (
     <TextAreaWrapper className={'ui form'}>
-      <SemanticTextArea
-        autoHeight
+      <StyledSemanticTextArea
         placeholder={placeholder}
         value={inputValue}
-        onChange={(_, { value }) => setInputValue(value as string)}
+        onChange={(_, { value }) => onChange(value as string)}
       />
     </TextAreaWrapper>
   )

--- a/shared/hedvig-ui/typography.tsx
+++ b/shared/hedvig-ui/typography.tsx
@@ -34,6 +34,12 @@ export const Bold = styled.strong`
   color: inherit !important;
 `
 
+export const Shadowed = styled.span`
+  background-color: ${({ theme }) => theme.backgroundTransparent};
+  border-radius: 4px;
+  padding: 0.1em 0.35em;
+`
+
 export const ErrorText = styled.p`
   color: ${({ theme }) => theme.danger};
   font-weight: bold;

--- a/src/api/generated/graphql.tsx
+++ b/src/api/generated/graphql.tsx
@@ -3454,7 +3454,7 @@ export type SetCoveringEmployeeMutationVariables = Exact<{
 
 export type SetCoveringEmployeeMutation = { __typename?: 'MutationType' } & {
   setCoveringEmployee?: Maybe<
-    { __typename?: 'Claim' } & Pick<Claim, 'coveringEmployee'> & {
+    { __typename?: 'Claim' } & Pick<Claim, 'id' | 'coveringEmployee'> & {
         events: Array<
           { __typename?: 'ClaimEvent' } & Pick<ClaimEvent, 'text' | 'date'>
         >
@@ -8416,6 +8416,7 @@ export type SetContractForClaimMutationOptions = ApolloReactCommon.BaseMutationO
 export const SetCoveringEmployeeDocument = gql`
   mutation SetCoveringEmployee($id: ID!, $coveringEmployee: Boolean!) {
     setCoveringEmployee(id: $id, coveringEmployee: $coveringEmployee) {
+      id
       coveringEmployee
       events {
         text

--- a/src/api/generated/graphql.tsx
+++ b/src/api/generated/graphql.tsx
@@ -1839,6 +1839,8 @@ export type ClaimPageQuery = { __typename?: 'QueryType' } & {
             | 'contractTypeName'
             | 'preferredCurrency'
             | 'typeOfContract'
+            | 'masterInception'
+            | 'terminationDate'
           > & {
               genericAgreements: Array<
                 { __typename?: 'GenericAgreement' } & Pick<
@@ -3885,6 +3887,8 @@ export const ClaimPageDocument = gql`
         contractTypeName
         preferredCurrency
         typeOfContract
+        masterInception
+        terminationDate
       }
       agreement {
         id

--- a/src/components/claims/claim-details/components/ClaimEvents.tsx
+++ b/src/components/claims/claim-details/components/ClaimEvents.tsx
@@ -1,29 +1,13 @@
-import {
-  List as MuiList,
-  ListItem as MuiListItem,
-  withStyles,
-} from '@material-ui/core'
 import { useClaimPageQuery } from 'api/generated/graphql'
 import { PaperTitle } from 'components/claims/claim-details/components/claim-items/PaperTitle'
 import { format, parseISO } from 'date-fns'
 import { CardContent } from 'hedvig-ui/card'
+import { List, ListItem } from 'hedvig-ui/list'
 import { Spinner } from 'hedvig-ui/sipnner'
 import React from 'react'
 import { BugFill } from 'react-bootstrap-icons'
 
-interface Props {
-  claimId: string
-}
-
-const ListItem = withStyles({
-  root: {
-    paddingLeft: 0,
-    paddingRight: 0,
-    borderBottom: '1px solid rgba(0,0,0,0.08)',
-  },
-})(MuiListItem)
-
-export const ClaimEvents: React.FC<Props> = ({ claimId }) => {
+export const ClaimEvents: React.FC<{ claimId: string }> = ({ claimId }) => {
   const {
     data: claimEventsData,
     loading: loadingClaimEvents,
@@ -49,13 +33,13 @@ export const ClaimEvents: React.FC<Props> = ({ claimId }) => {
 
       {loadingClaimEvents && <Spinner />}
 
-      <MuiList>
+      <List>
         {claimEventsData?.claim?.events.filter(Boolean).map((event) => (
           <ListItem key={event.date}>
             {format(parseISO(event.date), 'yyyy-MM-dd HH:mm:ss')}: {event.text}
           </ListItem>
         ))}
-      </MuiList>
+      </List>
     </CardContent>
   )
 }

--- a/src/components/claims/claim-details/components/ClaimInformation.tsx
+++ b/src/components/claims/claim-details/components/ClaimInformation.tsx
@@ -7,6 +7,7 @@ import {
 } from 'api/generated/graphql'
 
 import { PaperTitle } from 'components/claims/claim-details/components/claim-items/PaperTitle'
+import { ContractDropdown } from 'components/claims/claim-details/components/ContractDropdown'
 import { format, parseISO } from 'date-fns'
 import {
   setContractForClaimOptions,
@@ -24,11 +25,9 @@ import { CardContent, CardsWrapper, DangerCard } from 'hedvig-ui/card'
 import { Dropdown, EnumDropdown } from 'hedvig-ui/dropdown'
 import { InfoRow, InfoText } from 'hedvig-ui/info-row'
 import { Loadable } from 'hedvig-ui/loadable'
-import { Label, Paragraph, Placeholder, Shadowed } from 'hedvig-ui/typography'
+import { Label, Paragraph } from 'hedvig-ui/typography'
 import React, { useState } from 'react'
 import { BugFill, CloudArrowDownFill } from 'react-bootstrap-icons'
-import { currentAgreementForContract } from 'utils/contract'
-import { convertEnumToTitle, getCarrierText } from 'utils/text'
 
 const validateSelectOption = (value: any): ClaimState => {
   if (!Object.values(ClaimState).includes(value as any)) {
@@ -95,96 +94,6 @@ const ClaimAudio: React.FC<{ recordingUrl: string }> = ({ recordingUrl }) => {
     </ClaimAudioWrapper>
   )
 }
-
-const ContractItemTypeName = styled.div`
-  font-size: 1.2em;
-  padding-bottom: 0.6em;
-`
-
-const ContractItemAddress = styled.div`
-  font-size: 0.8em;
-  padding-bottom: 0.25em;
-  color: ${({ theme }) => theme.semiStrongForeground};
-`
-
-const ContractItemCarrier = styled.div`
-  padding-top: 0.15em;
-  font-size: 0.9em;
-  padding-bottom: 0.8em;
-`
-
-const ContractItemDateRange = styled.div`
-  font-size: 0.8em;
-  color: ${({ theme }) => theme.semiStrongForeground};
-`
-
-const ContractItemLineOfBusiness = styled.div`
-  padding-top: 0.15em;
-  font-size: 0.9em;
-  padding-bottom: 0.8em;
-`
-
-const ContractItemTopTitle = styled.div`
-  display: flex;
-  flex-direction: row;
-  padding-top: 0.2em;
-  padding-bottom: 0.2em;
-  margin-bottom: 0.7em;
-  border-bottom: 1px solid ${({ theme }) => theme.backgroundTransparent};
-`
-
-const ContractDropdown = styled(Dropdown)`
-  .visible.menu.transition {
-    max-height: 500px;
-  }
-
-  &&&.selection.visible {
-    background-color: ${({ theme }) => theme.accentSecondary};
-  }
-
-  && .item:hover {
-    background-color: ${({ theme }) => theme.accentSecondary} !important;
-  }
-`
-
-const getContractDropdownItemContent = (contract: Contract) => {
-  const currentAgreement = currentAgreementForContract(contract)
-  const address = currentAgreement?.address
-  const lineOfBusiness =
-    currentAgreement && convertEnumToTitle(currentAgreement.lineOfBusinessName)
-
-  return (
-    <>
-      <ContractItemTopTitle>
-        {currentAgreement && (
-          <ContractItemCarrier>
-            <Shadowed>{getCarrierText(currentAgreement?.carrier)}</Shadowed>
-          </ContractItemCarrier>
-        )}
-        {lineOfBusiness && (
-          <ContractItemLineOfBusiness
-            style={{ paddingLeft: currentAgreement && '0.5em' }}
-          >
-            <Shadowed>{lineOfBusiness}</Shadowed>
-          </ContractItemLineOfBusiness>
-        )}
-      </ContractItemTopTitle>
-      <ContractItemTypeName>{contract.contractTypeName}</ContractItemTypeName>
-      {address && (
-        <>
-          <ContractItemAddress>{address && address.street}</ContractItemAddress>
-        </>
-      )}
-
-      <ContractItemDateRange>
-        {contract.masterInception}
-        {' - '}
-        {contract.terminationDate ? contract.terminationDate : 'Ongoing'}
-      </ContractItemDateRange>
-    </>
-  )
-}
-
 export const ClaimInformation: React.FC<{
   claimId: string
   memberId: string
@@ -274,13 +183,8 @@ export const ClaimInformation: React.FC<{
           <SelectWrapper>
             <Label>Contract for Claim</Label>
             <ContractDropdown
-              options={contracts
-                .filter((contract) => contract.id !== selectedContract?.id)
-                .map((contract) => ({
-                  key: contract.id,
-                  value: contract.id,
-                  content: getContractDropdownItemContent(contract as Contract),
-                }))}
+              contracts={contracts as Contract[]}
+              selectedContract={selectedContract as Contract}
               onChange={async (value) => {
                 await setContractForClaim(
                   setContractForClaimOptions({
@@ -291,16 +195,6 @@ export const ClaimInformation: React.FC<{
                 )
                 await refetch()
               }}
-              onRender={() => {
-                if (!selectedContract) {
-                  return <Placeholder>None selected</Placeholder>
-                }
-
-                return getContractDropdownItemContent(
-                  selectedContract as Contract,
-                )
-              }}
-              value={selectedContract?.id ?? 'none'}
             />
           </SelectWrapper>
         )}

--- a/src/components/claims/claim-details/components/ClaimInformation.tsx
+++ b/src/components/claims/claim-details/components/ClaimInformation.tsx
@@ -21,7 +21,7 @@ import {
   useUpdateClaimState,
 } from 'graphql/use-update-claim-state'
 import { CardContent, CardsWrapper, DangerCard } from 'hedvig-ui/card'
-import { EnumDropdown } from 'hedvig-ui/dropdown'
+import { Dropdown, EnumDropdown } from 'hedvig-ui/dropdown'
 import { InfoRow, InfoText } from 'hedvig-ui/info-row'
 import { Loadable } from 'hedvig-ui/loadable'
 import { Label, Paragraph } from 'hedvig-ui/typography'
@@ -37,10 +37,7 @@ const validateSelectOption = (value: any): ClaimState => {
   return value as ClaimState
 }
 
-const validateSelectEmployeeClaimOption = (
-  event: React.ChangeEvent<HTMLSelectElement>,
-): boolean => {
-  const { value } = event.target
+const validateSelectEmployeeClaimOption = (value: any): boolean => {
   return value === 'True'
 }
 
@@ -107,6 +104,7 @@ export const ClaimInformation: React.FC<{
     data,
     error: queryError,
     loading: claimInformationLoading,
+    refetch,
   } = useClaimPageQuery({
     variables: { claimId },
   })
@@ -165,45 +163,39 @@ export const ClaimInformation: React.FC<{
               )
             }}
           />
-          <MuiSelect
-            value={state || ''}
-            onChange={async (event) => {
-              await updateClaimState(
-                updateClaimStateOptions(claimId, validateSelectOption(event)),
-              )
-            }}
-          >
-            {Object.values(ClaimState).map((s) => (
-              <MuiMenuItem key={s} value={s}>
-                {s}
-              </MuiMenuItem>
-            ))}
-          </MuiSelect>
         </SelectWrapper>
         <SelectWrapper>
           <Label>Employee Claim</Label>
-          <MuiSelect
+          <Dropdown
             value={coveringEmployee ? 'True' : 'False'}
-            onChange={async (event) => {
+            onChange={async (value) => {
               await setCoveringEmployee(
                 setCoveringEmployeeOptions(
                   claimId,
-                  validateSelectEmployeeClaimOption(event),
+                  validateSelectEmployeeClaimOption(value),
                 ),
               )
+              await refetch()
             }}
-          >
-            <MuiMenuItem key={'True'} value={'True'}>
-              True
-            </MuiMenuItem>
-            <MuiMenuItem key={'False'} value={'False'}>
-              False
-            </MuiMenuItem>
-          </MuiSelect>
+            options={['True', 'False']}
+          />
         </SelectWrapper>
         {contracts && (
           <SelectWrapper>
             <Label>Contract for Claim</Label>
+            <Dropdown
+              options={[]}
+              onChange={async (value) => {
+                await setContractForClaim(
+                  setContractForClaimOptions({
+                    claimId,
+                    memberId,
+                    contractId: value,
+                  }),
+                )
+              }}
+              value={selectedContract?.id ? selectedContract.id : 'none'}
+            />
             <MuiSelect
               value={selectedContract?.id ? selectedContract.id : 'none'}
               onChange={async (event) => {

--- a/src/components/claims/claim-details/components/ClaimInformation.tsx
+++ b/src/components/claims/claim-details/components/ClaimInformation.tsx
@@ -21,6 +21,7 @@ import {
   useUpdateClaimState,
 } from 'graphql/use-update-claim-state'
 import { CardContent, CardsWrapper, DangerCard } from 'hedvig-ui/card'
+import { EnumDropdown } from 'hedvig-ui/dropdown'
 import { InfoRow, InfoText } from 'hedvig-ui/info-row'
 import { Loadable } from 'hedvig-ui/loadable'
 import { Label, Paragraph } from 'hedvig-ui/typography'
@@ -29,15 +30,7 @@ import { BugFill, CloudArrowDownFill } from 'react-bootstrap-icons'
 import { currentAgreementForContract } from 'utils/contract'
 import { convertEnumToTitle, getCarrierText } from 'utils/text'
 
-interface Props {
-  claimId: string
-  memberId: string
-}
-
-const validateSelectOption = (
-  event: React.ChangeEvent<HTMLSelectElement>,
-): ClaimState => {
-  const { value } = event.target
+const validateSelectOption = (value: any): ClaimState => {
   if (!Object.values(ClaimState).includes(value as any)) {
     throw new Error(`invalid ClaimState: ${value}`)
   }
@@ -69,8 +62,7 @@ const ClaimAudioWrapper = styled.div`
 
 const DownloadWrapper = styled.a`
   font-size: 1.5em;
-  margin: 0.5em 0em;
-  margin-left: 0.5em;
+  margin: 0.5em 0 0.5em 0.5em;
   padding-top: 0.4em;
 `
 
@@ -107,7 +99,10 @@ const ClaimAudio: React.FC<{ recordingUrl: string }> = ({ recordingUrl }) => {
   )
 }
 
-export const ClaimInformation: React.FC<Props> = ({ claimId, memberId }) => {
+export const ClaimInformation: React.FC<{
+  claimId: string
+  memberId: string
+}> = ({ claimId, memberId }) => {
   const {
     data,
     error: queryError,
@@ -160,6 +155,16 @@ export const ClaimInformation: React.FC<Props> = ({ claimId, memberId }) => {
         {recordingUrl && <ClaimAudio recordingUrl={recordingUrl} />}
         <SelectWrapper>
           <Label>Status</Label>
+          <EnumDropdown
+            value={state || ''}
+            enumToSelectFrom={ClaimState}
+            placeholder={''}
+            setValue={async (value) => {
+              await updateClaimState(
+                updateClaimStateOptions(claimId, validateSelectOption(value)),
+              )
+            }}
+          />
           <MuiSelect
             value={state || ''}
             onChange={async (event) => {

--- a/src/components/claims/claim-details/components/ClaimInformation.tsx
+++ b/src/components/claims/claim-details/components/ClaimInformation.tsx
@@ -66,6 +66,10 @@ const DownloadButton = styled(CloudArrowDownFill)`
   color: ${({ theme }) => theme.foreground};
 `
 
+const NoAgreementWarning = styled(Paragraph)`
+  margin-top: 1em;
+`
+
 const ClaimAudio: React.FC<{ recordingUrl: string }> = ({ recordingUrl }) => {
   const [canPlay, setCanPlay] = useState<null | boolean>(null)
 
@@ -156,7 +160,7 @@ export const ClaimInformation: React.FC<{
             value={state || ''}
             enumToSelectFrom={ClaimState}
             placeholder={''}
-            setValue={async (value) => {
+            onChange={async (value) => {
               await updateClaimState(
                 updateClaimStateOptions(claimId, validateSelectOption(value)),
               )
@@ -174,9 +178,11 @@ export const ClaimInformation: React.FC<{
                   validateSelectEmployeeClaimOption(value),
                 ),
               )
-              await refetch()
             }}
-            options={['True', 'False']}
+            options={[
+              { key: 0, value: 'True', text: 'True' },
+              { key: 1, value: 'False', text: 'False' },
+            ]}
           />
         </SelectWrapper>
         {contracts && (
@@ -199,9 +205,9 @@ export const ClaimInformation: React.FC<{
           </SelectWrapper>
         )}
         {!selectedAgreement && (
-          <Paragraph style={{ marginTop: '1.0em' }}>
+          <NoAgreementWarning>
             ⚠️ No agreement covers the claim on the date of loss
-          </Paragraph>
+          </NoAgreementWarning>
         )}
         {contracts.length === 0 && trials.length > 0 && (
           <CardsWrapper>

--- a/src/components/claims/claim-details/components/ClaimInformation.tsx
+++ b/src/components/claims/claim-details/components/ClaimInformation.tsx
@@ -24,7 +24,7 @@ import { CardContent, CardsWrapper, DangerCard } from 'hedvig-ui/card'
 import { Dropdown, EnumDropdown } from 'hedvig-ui/dropdown'
 import { InfoRow, InfoText } from 'hedvig-ui/info-row'
 import { Loadable } from 'hedvig-ui/loadable'
-import { Label, Paragraph, Shadowed } from 'hedvig-ui/typography'
+import { Label, Paragraph, Placeholder, Shadowed } from 'hedvig-ui/typography'
 import React, { useState } from 'react'
 import { BugFill, CloudArrowDownFill } from 'react-bootstrap-icons'
 import { currentAgreementForContract } from 'utils/contract'
@@ -293,7 +293,7 @@ export const ClaimInformation: React.FC<{
               }}
               onRender={() => {
                 if (!selectedContract) {
-                  return null
+                  return <Placeholder>None selected</Placeholder>
                 }
 
                 return getContractDropdownItemContent(

--- a/src/components/claims/claim-details/components/ClaimNotes.tsx
+++ b/src/components/claims/claim-details/components/ClaimNotes.tsx
@@ -29,7 +29,6 @@ const ClaimNoteWrapper = styled.div`
   align-items: center;
   justify-content: space-between;
   padding: 0 0 0.5em;
-  border-bottom: 1px solid ${({ theme }) => theme.backgroundTransparent};
 `
 
 const ClaimNote = styled(Paragraph)`

--- a/src/components/claims/claim-details/components/ClaimPayment.tsx
+++ b/src/components/claims/claim-details/components/ClaimPayment.tsx
@@ -27,15 +27,6 @@ import { TextField } from '../../../shared/inputs/TextField'
 import { MutationFeedbackBlock } from '../../../shared/MutationFeedbackBlock'
 import { PaymentConfirmationDialog } from './PaymentConfirmationDialog'
 
-interface Props {
-  sanctionStatus?: SanctionStatus | null
-  claimId: string
-  refetch: () => Promise<any>
-  identified: boolean
-  market: string
-  carrier: string
-}
-
 export interface PaymentFormData {
   amount: string
   deductible: string
@@ -108,7 +99,14 @@ const getPaymentValidationSchema = (isPotentiallySanctioned: boolean) =>
     }),
   })
 
-export const ClaimPaymentComponent: React.FC<WithShowNotification & Props> = ({
+export const ClaimPaymentComponent: React.FC<WithShowNotification & {
+  sanctionStatus?: SanctionStatus | null
+  claimId: string
+  refetch: () => Promise<any>
+  identified: boolean
+  market: string
+  carrier: string
+}> = ({
   sanctionStatus,
   claimId,
   refetch,

--- a/src/components/claims/claim-details/components/ClaimPayments.tsx
+++ b/src/components/claims/claim-details/components/ClaimPayments.tsx
@@ -164,7 +164,7 @@ export const ClaimPayments: React.FC<{ claimId: string; carrier?: string }> = ({
         />
       </div>
 
-      {payments.length !== 0 ? (
+      {payments.length ? (
         <ScrollX>
           {loadingPayments && <Spinner />}
           <PaymentTable>

--- a/src/components/claims/claim-details/components/ClaimPayments.tsx
+++ b/src/components/claims/claim-details/components/ClaimPayments.tsx
@@ -91,7 +91,7 @@ export const ClaimPayments: React.FC<{ claimId: string; carrier?: string }> = ({
     .map((payment) => +payment?.deductible?.amount)
     .reduce((acc, amount) => acc + amount, 0)
 
-  if (carrier) {
+  if (!carrier) {
     return (
       <CardContent>
         <PaperTitle title={'Payments'} />

--- a/src/components/claims/claim-details/components/ClaimPayments.tsx
+++ b/src/components/claims/claim-details/components/ClaimPayments.tsx
@@ -12,19 +12,16 @@ import { format, parseISO } from 'date-fns'
 import { Spinner } from 'hedvig-ui/sipnner'
 
 import { PaperTitle } from 'components/claims/claim-details/components/claim-items/PaperTitle'
+import { StandaloneMessage } from 'hedvig-ui/animations/standalone-message'
 import { CardContent } from 'hedvig-ui/card'
 import { InfoRow, InfoTag, InfoText } from 'hedvig-ui/info-row'
-import { ThirdLevelHeadline } from 'hedvig-ui/typography'
+import { Paragraph, Shadowed, ThirdLevelHeadline } from 'hedvig-ui/typography'
 import React from 'react'
 import { BugFill } from 'react-bootstrap-icons'
 import { Market } from 'types/enums'
 import { Checkmark, Cross } from '../../../icons'
 import { ClaimPayment } from './ClaimPayment'
 import { ClaimReserves } from './ClaimReserves'
-
-interface Props {
-  claimId: string
-}
 
 const ScrollX = styled.div`
   overflow-x: scroll;
@@ -55,7 +52,24 @@ const MemberIdentityCard = styled.div`
   margin-right: 2em;
 `
 
-export const ClaimPayments: React.FC<Props> = ({ claimId }) => {
+const NoPaymentsMessage = styled(StandaloneMessage)`
+  padding: 3em 0;
+`
+
+const NoCarrierMessage = styled(StandaloneMessage)`
+  padding: 3em 0;
+  text-align: center;
+`
+
+const NoCarrierSubtitle = styled(Paragraph)`
+  font-size: 0.8em;
+  padding-top: 1em;
+`
+
+export const ClaimPayments: React.FC<{ claimId: string; carrier?: string }> = ({
+  claimId,
+  carrier,
+}) => {
   const {
     data: paymentsData,
     refetch: refetchPayments,
@@ -76,6 +90,22 @@ export const ClaimPayments: React.FC<Props> = ({ claimId }) => {
   const totalDeductible = payments
     .map((payment) => +payment?.deductible?.amount)
     .reduce((acc, amount) => acc + amount, 0)
+
+  if (carrier) {
+    return (
+      <CardContent>
+        <PaperTitle title={'Payments'} />
+        <NoCarrierMessage opacity={0.6}>
+          Cannot make a payment or set a reserve without a carrier.
+          <NoCarrierSubtitle>
+            Select a <Shadowed>Contract</Shadowed> and{' '}
+            <Shadowed>Date of Occurrence</Shadowed> such that the claim is
+            covered on the date.
+          </NoCarrierSubtitle>
+        </NoCarrierMessage>
+      </CardContent>
+    )
+  }
 
   return (
     <CardContent>
@@ -134,68 +164,72 @@ export const ClaimPayments: React.FC<Props> = ({ claimId }) => {
         />
       </div>
 
-      <ScrollX>
-        {loadingPayments && <Spinner />}
-        <PaymentTable>
-          <MuiTableHead>
-            <MuiTableRow>
-              <PaymentTableCell>Id</PaymentTableCell>
-              <PaymentTableCell>Amount</PaymentTableCell>
-              <PaymentTableCell>Deductible</PaymentTableCell>
-              <PaymentTableCell>Note</PaymentTableCell>
-              <PaymentTableCell>Date</PaymentTableCell>
-              <PaymentTableCell>Ex Gratia</PaymentTableCell>
-              <PaymentTableCell>Type</PaymentTableCell>
-              <PaymentTableCell>Status</PaymentTableCell>
-            </MuiTableRow>
-          </MuiTableHead>
-          <MuiTableBody>
-            {payments.map((payment) => (
-              <MuiTableRow key={payment.id}>
-                <PaymentTableCell>{payment.id}</PaymentTableCell>
-                <PaymentTableCell>
-                  {payment.amount.amount}&nbsp;{payment.amount.currency}
-                </PaymentTableCell>
-                <PaymentTableCell>
-                  {payment.deductible.amount}&nbsp;
-                  {payment.deductible.currency}
-                </PaymentTableCell>
-                <PaymentTableCell>{payment.note}</PaymentTableCell>
-                <PaymentTableCell>
-                  {format(parseISO(payment.timestamp), 'yyyy-MM-dd HH:mm:ss')}
-                </PaymentTableCell>
-                <PaymentTableCell>
-                  {payment.exGratia ? <Checkmark /> : <Cross />}
-                </PaymentTableCell>
-                <PaymentTableCell>{payment.type}</PaymentTableCell>
-                <PaymentTableCell>{payment.status}</PaymentTableCell>
+      {payments.length !== 0 ? (
+        <ScrollX>
+          {loadingPayments && <Spinner />}
+          <PaymentTable>
+            <MuiTableHead>
+              <MuiTableRow>
+                <PaymentTableCell>Id</PaymentTableCell>
+                <PaymentTableCell>Amount</PaymentTableCell>
+                <PaymentTableCell>Deductible</PaymentTableCell>
+                <PaymentTableCell>Note</PaymentTableCell>
+                <PaymentTableCell>Date</PaymentTableCell>
+                <PaymentTableCell>Ex Gratia</PaymentTableCell>
+                <PaymentTableCell>Type</PaymentTableCell>
+                <PaymentTableCell>Status</PaymentTableCell>
               </MuiTableRow>
-            ))}
-            {totalAmount > 0 && (
-              <>
-                <MuiTableRow>
-                  <TotalCell>
-                    <b>Amount Total: </b>
-                  </TotalCell>
-                  <TotalCell align="right">
-                    {totalAmount.toFixed(2)}&nbsp;
-                    {payments[0]!.amount.currency}
-                  </TotalCell>
+            </MuiTableHead>
+            <MuiTableBody>
+              {payments.map((payment) => (
+                <MuiTableRow key={payment.id}>
+                  <PaymentTableCell>{payment.id}</PaymentTableCell>
+                  <PaymentTableCell>
+                    {payment.amount.amount}&nbsp;{payment.amount.currency}
+                  </PaymentTableCell>
+                  <PaymentTableCell>
+                    {payment.deductible.amount}&nbsp;
+                    {payment.deductible.currency}
+                  </PaymentTableCell>
+                  <PaymentTableCell>{payment.note}</PaymentTableCell>
+                  <PaymentTableCell>
+                    {format(parseISO(payment.timestamp), 'yyyy-MM-dd HH:mm:ss')}
+                  </PaymentTableCell>
+                  <PaymentTableCell>
+                    {payment.exGratia ? <Checkmark /> : <Cross />}
+                  </PaymentTableCell>
+                  <PaymentTableCell>{payment.type}</PaymentTableCell>
+                  <PaymentTableCell>{payment.status}</PaymentTableCell>
                 </MuiTableRow>
-                <MuiTableRow>
-                  <TotalCell>
-                    <b>Deductible Total: </b>
-                  </TotalCell>
-                  <TotalCell align="right">
-                    {totalDeductible.toFixed(2)}&nbsp;
-                    {payments[0]!.deductible.currency}
-                  </TotalCell>
-                </MuiTableRow>
-              </>
-            )}
-          </MuiTableBody>
-        </PaymentTable>
-      </ScrollX>
+              ))}
+              {totalAmount > 0 && (
+                <>
+                  <MuiTableRow>
+                    <TotalCell>
+                      <b>Amount Total: </b>
+                    </TotalCell>
+                    <TotalCell align="right">
+                      {totalAmount.toFixed(2)}&nbsp;
+                      {payments[0]!.amount.currency}
+                    </TotalCell>
+                  </MuiTableRow>
+                  <MuiTableRow>
+                    <TotalCell>
+                      <b>Deductible Total: </b>
+                    </TotalCell>
+                    <TotalCell align="right">
+                      {totalDeductible.toFixed(2)}&nbsp;
+                      {payments[0]!.deductible.currency}
+                    </TotalCell>
+                  </MuiTableRow>
+                </>
+              )}
+            </MuiTableBody>
+          </PaymentTable>
+        </ScrollX>
+      ) : (
+        <NoPaymentsMessage>No payments have been made</NoPaymentsMessage>
+      )}
 
       {!loadingPayments &&
         paymentsData?.claim?.contract &&

--- a/src/components/claims/claim-details/components/ClaimReserveForm.tsx
+++ b/src/components/claims/claim-details/components/ClaimReserveForm.tsx
@@ -1,4 +1,7 @@
-import { useUpdateReserveMutation } from 'api/generated/graphql'
+import {
+  ClaimPaymentsDocument,
+  useUpdateReserveMutation,
+} from 'api/generated/graphql'
 import React, { useState } from 'react'
 
 import { Button } from 'hedvig-ui/button'
@@ -30,7 +33,11 @@ const ClaimReserveForm: React.FC<{ claimId: string }> = ({ claimId }) => {
                 currency: 'SEK',
               },
             },
+            refetchQueries: [
+              { query: ClaimPaymentsDocument, variables: { claimId } },
+            ],
           })
+          setValue('')
         }}
       >
         Update Reserve

--- a/src/components/claims/claim-details/components/ClaimReserveForm.tsx
+++ b/src/components/claims/claim-details/components/ClaimReserveForm.tsx
@@ -1,71 +1,41 @@
-import styled from '@emotion/styled'
-import { Button as MuiButton, withStyles } from '@material-ui/core'
 import { useUpdateReserveMutation } from 'api/generated/graphql'
-import { Field, Form, Formik } from 'formik'
-import React from 'react'
-import * as yup from 'yup'
+import React, { useState } from 'react'
 
-import { TextField } from '../../../shared/inputs/TextField'
+import { Button } from 'hedvig-ui/button'
+import { Input } from 'hedvig-ui/input'
+import { Spacing } from 'hedvig-ui/spacing'
 
-interface Props {
-  claimId: string
-  refetch: () => Promise<any>
-}
+const isStringNumber = (s: string) => /^-?\d+$/.test(s) || /^\d+\.\d+$/.test(s)
 
-interface ReserveFormData {
-  amount: number
-}
-
-const validationSchema = yup.object().shape({
-  amount: yup.string().required(),
-})
-
-const ReserveForm = styled(Form)({})
-
-const SubmitButton = withStyles({
-  root: {
-    marginTop: '1rem',
-  },
-})(MuiButton)
-
-const ClaimReserveForm: React.FC<Props> = ({ claimId }) => {
-  const [updateReserve] = useUpdateReserveMutation()
+const ClaimReserveForm: React.FC<{ claimId: string }> = ({ claimId }) => {
+  const [updateReserve, { loading }] = useUpdateReserveMutation()
+  const [value, setValue] = useState('')
 
   return (
-    <Formik<ReserveFormData>
-      initialValues={{ amount: 0 }}
-      onSubmit={async (values, { resetForm }) => {
-        await updateReserve({
-          variables: {
-            claimId,
-            amount: {
-              amount: +values.amount,
-              currency: 'SEK',
+    <>
+      <Input
+        placeholder={'Reserve amount'}
+        onChange={(e) => setValue(e.currentTarget.value)}
+      />
+      <Spacing top={'small'} />
+      <Button
+        variation="primary"
+        disabled={!isStringNumber(value) || value === '' || loading}
+        onClick={async () => {
+          await updateReserve({
+            variables: {
+              claimId,
+              amount: {
+                amount: value,
+                currency: 'SEK',
+              },
             },
-          },
-        })
-        resetForm()
-      }}
-      validationSchema={validationSchema}
-    >
-      {({ isValid, isSubmitting }) => (
-        <ReserveForm>
-          <Field
-            component={TextField}
-            placeholder={'Reserve amount'}
-            name="amount"
-          />
-          <SubmitButton
-            type="submit"
-            variant="contained"
-            color="primary"
-            disabled={!isValid || isSubmitting}
-          >
-            Update Reserve
-          </SubmitButton>
-        </ReserveForm>
-      )}
-    </Formik>
+          })
+        }}
+      >
+        Update Reserve
+      </Button>
+    </>
   )
 }
 

--- a/src/components/claims/claim-details/components/ClaimReserves.tsx
+++ b/src/components/claims/claim-details/components/ClaimReserves.tsx
@@ -32,16 +32,16 @@ const ReservesText = styled(Paragraph)`
   color: ${({ theme }) => theme.semiStrongForeground};
 `
 
-const ClaimReserves: React.FC<Props> = ({
+export const ClaimReserves: React.FC<Props> = ({
   claimId,
   reserves,
   loading,
-  refetch,
 }) => {
   const reserveAmount = reserves && reserves.amount ? reserves.amount : '0.00'
   const reserveCurrency =
     reserves && reserves.currency ? reserves.currency : 'SEK'
   const reserveAmountInteger = Math.round(Number(reserveAmount))
+
   return (
     <ReservesCard>
       <ThirdLevelHeadline>Reserves</ThirdLevelHeadline>
@@ -52,9 +52,7 @@ const ClaimReserves: React.FC<Props> = ({
         </ReservesTag>{' '}
         <ReservesText>reserved</ReservesText>
       </div>
-      <ClaimReserveForm claimId={claimId} refetch={refetch} />
+      <ClaimReserveForm claimId={claimId} />
     </ReservesCard>
   )
 }
-
-export { ClaimReserves }

--- a/src/components/claims/claim-details/components/ClaimTranscriptions.tsx
+++ b/src/components/claims/claim-details/components/ClaimTranscriptions.tsx
@@ -1,4 +1,3 @@
-import { List as MuiList } from '@material-ui/core'
 import { useClaimPageQuery } from 'api/generated/graphql'
 
 import React from 'react'
@@ -15,8 +14,6 @@ const ClaimTranscriptionWrapper = styled.div`
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  padding: 0 0 0.5em;
-  border-bottom: 1px solid ${({ theme }) => theme.backgroundTransparent};
 `
 
 const ClaimTranscription = styled(Paragraph)`
@@ -64,12 +61,12 @@ const ClaimTranscriptions: React.FC<{ claimId: string }> = ({ claimId }) => {
               <ListItem key={transcription.text}>
                 <ClaimTranscriptionWrapper>
                   <ClaimTranscription>{transcription.text}</ClaimTranscription>
-                  <MuiList>
+                  <List>
                     <ClaimTranscriptionMetaData>
                       Confidence: {transcription.confidenceScore}
                       <br /> Language code: {transcription.languageCode}
                     </ClaimTranscriptionMetaData>
-                  </MuiList>
+                  </List>
                 </ClaimTranscriptionWrapper>
               </ListItem>
             ),

--- a/src/components/claims/claim-details/components/ClaimTranscriptions.tsx
+++ b/src/components/claims/claim-details/components/ClaimTranscriptions.tsx
@@ -1,47 +1,36 @@
-import {
-  List as MuiList,
-  ListItem as MuiListItem,
-  Typography as MuiTypography,
-  withStyles,
-} from '@material-ui/core'
+import { List as MuiList } from '@material-ui/core'
 import { useClaimPageQuery } from 'api/generated/graphql'
 
 import React from 'react'
 
+import styled from '@emotion/styled'
 import { PaperTitle } from 'components/claims/claim-details/components/claim-items/PaperTitle'
 import { Card, CardContent } from 'hedvig-ui/card'
+import { List, ListItem } from 'hedvig-ui/list'
+import { Paragraph } from 'hedvig-ui/typography'
 import { BugFill } from 'react-bootstrap-icons'
 
-interface Props {
-  claimId: string
-}
+const ClaimTranscriptionWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 0 0.5em;
+  border-bottom: 1px solid ${({ theme }) => theme.backgroundTransparent};
+`
 
-const ListItem = withStyles({
-  root: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingLeft: 0,
-    paddingRight: 0,
-    borderBottom: '1px solid rgba(0,0,0,0.08)',
-  },
-})(MuiListItem)
+const ClaimTranscription = styled(Paragraph)`
+  font-size: 1rem;
+  max-width: 80%;
+  white-space: pre-wrap;
+`
 
-const ClaimTranscription = withStyles({
-  root: {
-    fontSize: '1rem',
-    maxWidth: '80%',
-  },
-})(MuiTypography)
+const ClaimTranscriptionMetaData = styled(Paragraph)`
+  font-size: 0.875rem;
+  text-align: right;
+`
 
-const ClaimTranscriptionMetaData = withStyles({
-  root: {
-    fontSize: '0.875rem',
-  },
-})(MuiTypography)
-
-const ClaimTranscriptions: React.FC<Props> = ({ claimId }) => {
+const ClaimTranscriptions: React.FC<{ claimId: string }> = ({ claimId }) => {
   const {
     data: claimTranscriptionsData,
     error: queryError,
@@ -69,23 +58,23 @@ const ClaimTranscriptions: React.FC<Props> = ({ claimId }) => {
           }
         />
 
-        <MuiList>
+        <List>
           {claimTranscriptionsData?.claim?.transcriptions?.map(
             (transcription) => (
               <ListItem key={transcription.text}>
-                <ClaimTranscription component="p">
-                  {transcription.text}
-                </ClaimTranscription>
-                <MuiList>
-                  <ClaimTranscriptionMetaData component="span">
-                    Confidence: {transcription.confidenceScore}
-                    <br /> Language code: {transcription.languageCode}
-                  </ClaimTranscriptionMetaData>
-                </MuiList>
+                <ClaimTranscriptionWrapper>
+                  <ClaimTranscription>{transcription.text}</ClaimTranscription>
+                  <MuiList>
+                    <ClaimTranscriptionMetaData>
+                      Confidence: {transcription.confidenceScore}
+                      <br /> Language code: {transcription.languageCode}
+                    </ClaimTranscriptionMetaData>
+                  </MuiList>
+                </ClaimTranscriptionWrapper>
               </ListItem>
             ),
           )}
-        </MuiList>
+        </List>
       </CardContent>
     </Card>
   )

--- a/src/components/claims/claim-details/components/ContractDropdown.tsx
+++ b/src/components/claims/claim-details/components/ContractDropdown.tsx
@@ -1,0 +1,123 @@
+import styled from '@emotion/styled'
+import { Contract } from 'api/generated/graphql'
+import { Dropdown } from 'hedvig-ui/dropdown'
+import { Placeholder, Shadowed } from 'hedvig-ui/typography'
+import React from 'react'
+import { currentAgreementForContract } from 'utils/contract'
+import { convertEnumToTitle, getCarrierText } from 'utils/text'
+
+const ContractItemTypeName = styled.div`
+  font-size: 1.2em;
+  padding-bottom: 0.6em;
+`
+
+const ContractItemAddress = styled.div`
+  font-size: 0.8em;
+  padding-bottom: 0.25em;
+  color: ${({ theme }) => theme.semiStrongForeground};
+`
+
+const ContractItemCarrier = styled.div`
+  padding-top: 0.15em;
+  font-size: 0.9em;
+  padding-bottom: 0.8em;
+`
+
+const ContractItemDateRange = styled.div`
+  font-size: 0.8em;
+  color: ${({ theme }) => theme.semiStrongForeground};
+`
+
+const ContractItemLineOfBusiness = styled.div`
+  padding-top: 0.15em;
+  font-size: 0.9em;
+  padding-bottom: 0.8em;
+`
+
+const ContractItemTopTitle = styled.div`
+  display: flex;
+  flex-direction: row;
+  padding-top: 0.2em;
+  padding-bottom: 0.2em;
+  margin-bottom: 0.7em;
+  border-bottom: 1px solid ${({ theme }) => theme.backgroundTransparent};
+`
+
+const StyledContractDropdown = styled(Dropdown)`
+  .visible.menu.transition {
+    max-height: 500px;
+  }
+
+  &&&.selection.visible {
+    background-color: ${({ theme }) => theme.accentSecondary};
+  }
+
+  && .item:hover {
+    background-color: ${({ theme }) => theme.accentSecondary} !important;
+  }
+`
+
+const ContractItem: React.FC<{ contract: Contract }> = ({ contract }) => {
+  const currentAgreement = currentAgreementForContract(contract)
+  const address = currentAgreement?.address
+  const lineOfBusiness =
+    currentAgreement && convertEnumToTitle(currentAgreement.lineOfBusinessName)
+
+  return (
+    <>
+      <ContractItemTopTitle>
+        {currentAgreement && (
+          <ContractItemCarrier>
+            <Shadowed>{getCarrierText(currentAgreement?.carrier)}</Shadowed>
+          </ContractItemCarrier>
+        )}
+        {lineOfBusiness && (
+          <ContractItemLineOfBusiness
+            style={{ paddingLeft: currentAgreement && '0.5em' }}
+          >
+            <Shadowed>{lineOfBusiness}</Shadowed>
+          </ContractItemLineOfBusiness>
+        )}
+      </ContractItemTopTitle>
+      <ContractItemTypeName>{contract.contractTypeName}</ContractItemTypeName>
+      {address && (
+        <>
+          <ContractItemAddress>{address && address.street}</ContractItemAddress>
+        </>
+      )}
+
+      <ContractItemDateRange>
+        {contract.masterInception}
+        {' - '}
+        {contract.terminationDate ? contract.terminationDate : 'Ongoing'}
+      </ContractItemDateRange>
+    </>
+  )
+}
+
+export const ContractDropdown: React.FC<{
+  contracts: Contract[]
+  selectedContract: Contract
+  onChange: (value: string) => void
+}> = ({ contracts, selectedContract, onChange }) => {
+  return (
+    <StyledContractDropdown
+      options={contracts
+        .filter((contract) => contract.id !== selectedContract?.id)
+        .map((contract) => ({
+          key: contract.id,
+          value: contract.id,
+          content: <ContractItem contract={contract} />,
+        }))}
+      onChange={onChange}
+      onRender={() => {
+        if (!selectedContract) {
+          return <Placeholder>None selected</Placeholder>
+        }
+
+        return <ContractItem contract={selectedContract} />
+      }}
+      value={selectedContract?.id ?? 'none'}
+    />
+  )
+}

--- a/src/components/claims/claim-details/graphql/claim-page-query.graphql
+++ b/src/components/claims/claim-details/graphql/claim-page-query.graphql
@@ -33,6 +33,8 @@ query ClaimPage($claimId: ID!) {
       contractTypeName
       preferredCurrency
       typeOfContract
+      masterInception
+      terminationDate
     }
 
     agreement {

--- a/src/components/claims/claim-details/index.tsx
+++ b/src/components/claims/claim-details/index.tsx
@@ -3,7 +3,6 @@ import { ClaimState, useClaimPageQuery } from 'api/generated/graphql'
 import { ClaimItems } from 'components/claims/claim-details/components/claim-items'
 import { ChatPane } from 'components/member/tabs/ChatPane'
 import { FadeIn } from 'hedvig-ui/animations/fade-in'
-import { StandaloneMessage } from 'hedvig-ui/animations/standalone-message'
 import { Card, CardsWrapper } from 'hedvig-ui/card'
 import { MainHeadline } from 'hedvig-ui/typography'
 import React, { useContext, useEffect } from 'react'
@@ -75,26 +74,22 @@ export const ClaimDetails: React.FC<RouteComponentProps<{
               <ClaimItems claimId={claimId} memberId={memberId} />
             </Card>
           </CardsWrapper>
-          {claimPageData?.claim?.agreement?.carrier ? (
+          {claimPageData?.claim?.agreement?.carrier && (
             <>
               <MainHeadline>
                 {getCarrierText(claimPageData.claim.agreement.carrier)}
               </MainHeadline>
-              <CardsWrapper contentWrap={'noWrap'}>
-                <Card>
-                  <ClaimPayments claimId={claimId} />
-                </Card>
-              </CardsWrapper>
             </>
-          ) : (
-            <StandaloneMessage opacity={1.0}>
-              ⚠️ Cannot make a payment or set a reserve without carrier, select
-              a <strong>Contract</strong> and{' '}
-              <strong>Date of Occurrence</strong>. Also, make sure the claim is{' '}
-              <strong>covered on the date</strong> (i.e. an agreement is active
-              on the date of occurrence)
-            </StandaloneMessage>
           )}
+
+          <CardsWrapper contentWrap={'noWrap'}>
+            <Card>
+              <ClaimPayments
+                claimId={claimId}
+                carrier={claimPageData?.claim?.agreement?.carrier}
+              />
+            </Card>
+          </CardsWrapper>
 
           <CardsWrapper contentWrap={'noWrap'}>
             <Card>

--- a/src/components/member/tabs/ClaimsTab.tsx
+++ b/src/components/member/tabs/ClaimsTab.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled'
 import { ClaimSource, useCreateClaimMutation } from 'api/generated/graphql'
 import { ClaimListHeader } from 'components/claims/claims-list/components/ClaimListHeader'
 import { ClaimListItem } from 'components/claims/claims-list/components/ClaimListItem'
@@ -16,7 +17,6 @@ import { Spacing } from 'hedvig-ui/spacing'
 import { MainHeadline } from 'hedvig-ui/typography'
 import React from 'react'
 import { ArrowRepeat } from 'react-bootstrap-icons'
-import styled from '@emotion/styled'
 import { Table } from 'semantic-ui-react'
 import { WithShowNotification } from 'store/actions/notificationsActions'
 import { withShowNotification } from 'utils/notifications'
@@ -64,7 +64,7 @@ const ClaimsTabComponent: React.FC<{
               <EnumDropdown
                 enumToSelectFrom={ClaimSource}
                 placeholder={'Claim Source'}
-                setValue={(source) => setClaimSource(source)}
+                onChange={(source) => setClaimSource(source)}
               />
               <Spacing left={'small'}>
                 <DateTimePicker

--- a/src/components/member/tabs/contracts-tab/contract/termination-date.tsx
+++ b/src/components/member/tabs/contracts-tab/contract/termination-date.tsx
@@ -183,7 +183,7 @@ const TerminationDateComponent: React.FC<{
             <TextArea
               placeholder={'Comment on the reason of termination...'}
               value={comment}
-              setValue={setComment}
+              onChange={setComment}
             />
           </Spacing>
           <ButtonsGroup>

--- a/src/components/member/tabs/contracts-tab/contract/termination-date.tsx
+++ b/src/components/member/tabs/contracts-tab/contract/termination-date.tsx
@@ -177,7 +177,7 @@ const TerminationDateComponent: React.FC<{
           <EnumDropdown
             enumToSelectFrom={TerminationReason}
             placeholder={'Termination reason'}
-            setValue={setTerminationReason}
+            onChange={setTerminationReason}
           />
           <Spacing top bottom>
             <TextArea

--- a/src/features/tools/itemizer/TableInput.tsx
+++ b/src/features/tools/itemizer/TableInput.tsx
@@ -59,7 +59,7 @@ export const TableInput: React.FC<{
         <TextArea
           placeholder={'Tab & newline separated table (i.e. Excel)'}
           value={dataString}
-          setValue={setDataString}
+          onChange={setDataString}
         />
       )}
       <Button

--- a/src/features/tools/norwegian-tariff-editor/factor-editor.tsx
+++ b/src/features/tools/norwegian-tariff-editor/factor-editor.tsx
@@ -23,7 +23,7 @@ export const FactorEditor: React.FC<FactorEditorProps> = ({
           <TextArea
             placeholder={`Add factors of ${factorName} from excel (Including the name of the factor, its keys on the left and the columns: 'Fire', 'Leakage', 'Other', 'All risk' and 'Travel' OBS: Do not include 'Special object')...`}
             value={factorString}
-            setValue={setFactorString}
+            onChange={setFactorString}
           />
         </Card>
       </CardsWrapper>

--- a/src/features/tools/norwegian-tariff-editor/index.tsx
+++ b/src/features/tools/norwegian-tariff-editor/index.tsx
@@ -48,7 +48,7 @@ const NorwegianTariffEditorComponent: React.FC<WithShowNotification> = ({
               'Add Base Factors from excel including "Product" (Columns: Fire, Leakage, Other, All risk and Travel), include "Base factor" and "Index per year"...'
             }
             value={baseFactors}
-            setValue={setBaseFactors}
+            onChange={setBaseFactors}
           />
         </Card>
       </CardsWrapper>

--- a/src/features/tools/norwegian-tariff-editor/postal-codes-editor.tsx
+++ b/src/features/tools/norwegian-tariff-editor/postal-codes-editor.tsx
@@ -27,7 +27,7 @@ export const PostalCodesEditor: React.FC<PostalCodesEditorProps> = ({
           'Add postal codes columns from excel (Columns: "Postnummer", "Poststed", "Municipality name", "Disposable income" and "Centrality group")'
         }
         value={postalCodesString}
-        setValue={setPostalCodesString}
+        onChange={setPostalCodesString}
       />
       <Spacing top>
         <Button

--- a/src/features/tools/switcher-automation/SwitcherTableRow.tsx
+++ b/src/features/tools/switcher-automation/SwitcherTableRow.tsx
@@ -313,7 +313,7 @@ const SwitcherEmailRowComponent: React.FC<Pick<
                   <EnumDropdown
                     enumToSelectFrom={TerminationReason}
                     placeholder={''}
-                    setValue={setTerminationReason}
+                    onChange={setTerminationReason}
                   />
                 </OverlayItem>
                 <OverlayItem>

--- a/src/graphql/set-covering-employee.graphql
+++ b/src/graphql/set-covering-employee.graphql
@@ -1,5 +1,6 @@
 mutation SetCoveringEmployee($id: ID!, $coveringEmployee: Boolean!) {
   setCoveringEmployee(id: $id, coveringEmployee: $coveringEmployee) {
+    id
     coveringEmployee
     events {
       text


### PR DESCRIPTION
## What?
- Add `List` component to `hedvig-ui`
- Add `Dropdown` component to `hedvig-ui`
- Make `Dropdown` and `EnumDropdown` automatically show loading indicator if their `onChange` is async
- Add `Shadowed` to `@hedvig-ui/typography`
- Replace a lot (not all) of `material-ui` components with `hedvig-ui` equivalents
- Remove some good 'ol `Formik` forms
- Don’t render claim payment table if it is empty, but show appropriate message
- Update the “Contract for Claim” dropdown under Claim Information

## Why?
- We're trying to move away from `material-ui` and instead use our own `hedvig-ui` components to (1) facilitate and speed up development of new features; (2) provide consistency to Hope. It should be easy to make things pretty, intuitive and efficient for the users of Hope.
- Hope is kind of slow (not as bad as it was before though), and we're aiming to reduce the number of heavy packages (where `material-ui` currently is our main target)

## Optional screenshots

### Claim Information

Before             |  After
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/51323202/128996331-d71fae18-51d0-4de8-b4fd-ae9557d565c3.png" width="90%"> | <img src="https://user-images.githubusercontent.com/51323202/128996073-6bc2ebd2-7518-426b-b165-4672c3f944c0.png" width="90%">

### Payments

Before
![image](https://user-images.githubusercontent.com/51323202/128996717-3d399838-ac38-45ff-b287-b0eed6b19521.png)

After
![image](https://user-images.githubusercontent.com/51323202/128996596-cd0941c4-3aee-48bc-9f32-ce3960cfa44c.png)


## Optional checklist
- [ ] Updated `src/changelog.ts`
- [x] Codescouted
- [ ] Unit tests written
- [x] Tested locally

