### PR TITLE
Use LocalStorage instead of window

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -13,13 +13,13 @@ const axiosInstance = axios.create({
 })
 
 export const refreshAccessToken = async () => {
-  if ((window as any).__hvg_refreshingAccessToken) {
+  if (localStorage.getItem('hvg:refreshingAccessToken') === 'true') {
     // bail if we're already refreshing
     return
   }
 
   try {
-    ;(window as any).__hvg_refreshingAccessToken = true
+    localStorage.setItem('hvg:refreshingAccessToken', 'true')
     await axios.post('/login/refresh', null, {
       headers: {
         accept: 'application/json',
@@ -29,7 +29,7 @@ export const refreshAccessToken = async () => {
     })
     await axiosInstance.post('/settings/auth-success')
   } finally {
-    ;(window as any).__hvg_refreshingAccessToken = false
+    localStorage.setItem('hvg:refreshingAccessToken', 'false')
   }
 }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -12,14 +12,40 @@ const axiosInstance = axios.create({
   },
 })
 
+const setItemWithExpiry = (key, value, ttl) =>
+  localStorage.setItem(
+    key,
+    JSON.stringify({
+      value,
+      expiry: new Date().getTime() + ttl,
+    }),
+  )
+
+const getItemWithExpiry = (key) => {
+  const itemStr = localStorage.getItem(key)
+
+  if (!itemStr) {
+    return null
+  }
+
+  const item = JSON.parse(itemStr)
+
+  if (new Date().getTime() > item.expiry) {
+    localStorage.removeItem(key)
+    return null
+  }
+
+  return item.value
+}
+
 export const refreshAccessToken = async () => {
-  if (localStorage.getItem('hvg:refreshingAccessToken') === 'true') {
+  if (getItemWithExpiry('hvg:refreshingAccessToken') === 'true') {
     // bail if we're already refreshing
     return
   }
 
   try {
-    localStorage.setItem('hvg:refreshingAccessToken', 'true')
+    setItemWithExpiry('hvg:refreshingAccessToken', 'true', 10000)
     await axios.post('/login/refresh', null, {
       headers: {
         accept: 'application/json',
@@ -29,7 +55,7 @@ export const refreshAccessToken = async () => {
     })
     await axiosInstance.post('/settings/auth-success')
   } finally {
-    localStorage.setItem('hvg:refreshingAccessToken', 'false')
+    localStorage.removeItem('hvg:refreshingAccessToken')
   }
 }
 


### PR DESCRIPTION
## Why

LocalStorage is saved per `protocol://domain:port/`, as opposed to `window` which is per tab

