### PR TITLE
Only refresh token from active tab

### DIFF
--- a/src/api/apollo-client.ts
+++ b/src/api/apollo-client.ts
@@ -18,7 +18,10 @@ export const apolloClient = (() => {
   return new ApolloClient({
     link: ApolloLink.from([
       onError((error) => {
-        if ((error?.networkError as ServerError)?.response?.status !== 403) {
+        if (
+          document.hidden ||
+          (error?.networkError as ServerError)?.response?.status !== 403
+        ) {
           return
         }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosResponse } from 'axios'
-import { forceLogOut } from 'utils/auth'
+import { forceLogOut } from '../utils/auth'
 import config from './config'
 
 const axiosInstance = axios.create({
@@ -21,7 +21,7 @@ const setItemWithExpiry = (key, value, ttl) =>
     }),
   )
 
-const getItemWithExpiry = (key) => {
+export const getItemWithExpiry = (key) => {
   const itemStr = localStorage.getItem(key)
 
   if (!itemStr) {


### PR DESCRIPTION
To stop race conditions when trying to refresh tokens in multiple tabs 🥴

