### PR TITLE
Add current tab to member link

### DIFF
--- a/src/features/member/index.tsx
+++ b/src/features/member/index.tsx
@@ -106,7 +106,7 @@ export const MemberTabs: React.FC<RouteComponentProps<{
       keys: [Keys.Option, Keys.M],
       onResolve: () => {
         copy(
-          `${window.location.protocol}//${window.location.host}/members/${memberId}`,
+          `${window.location.protocol}//${window.location.host}${history.location.pathname}`,
           {
             format: 'text/plain',
           },
@@ -245,11 +245,11 @@ export const MemberTabs: React.FC<RouteComponentProps<{
           )}
           <Popover contents="Click to copy">
             <MemberDetailLink
-              href={`${window.location.protocol}//${window.location.host}/members/${memberId}`}
+              href={`${window.location.protocol}//${window.location.host}${history.location.pathname}`}
               onClick={(e) => {
                 e.preventDefault()
                 copy(
-                  `${window.location.protocol}//${window.location.host}/members/${memberId}`,
+                  `${window.location.protocol}//${window.location.host}${history.location.pathname}`,
                   {
                     format: 'text/plain',
                   },


### PR DESCRIPTION
# Jira Issue: [IP-65](https://hedvig.atlassian.net/jira/software/projects/IP/boards/19?selectedIssue=IP-65)

## What?
Add current tab to member link

## Why?
For better sharing of members

## Video
https://user-images.githubusercontent.com/89198006/134112468-d5d981d3-932c-41fc-b012-8f60cf1ecf2e.mov


## Optional checklist
- [ ] Updated `src/changelog.ts`
- [ ] Codescouted
- [ ] Unit tests written
- [ ] Tested locally

