### PR TITLE
Have different modifiers for Windows, fix sending messages for Conversations

### DIFF
--- a/shared/@hedvig-ui/TextArea/text-area.tsx
+++ b/shared/@hedvig-ui/TextArea/text-area.tsx
@@ -49,7 +49,10 @@ export const TextArea: React.FC<{
           onChange={(_, { value }) => onChange(value as string)}
           {...props}
           onKeyDown={(e) => {
-            if (shouldIgnoreInput(e.key)) {
+            if (
+              shouldIgnoreInput(e.key) ||
+              (!inputValue && e.keyCode === Keys.Enter.code)
+            ) {
               e.preventDefault()
               return
             }

--- a/shared/@hedvig-ui/utils/key-press-hook.tsx
+++ b/shared/@hedvig-ui/utils/key-press-hook.tsx
@@ -8,59 +8,59 @@ export interface Key {
 export const Keys: { [name: string]: Key } = {
   Escape: {
     code: 27,
-    hint: 'esc',
+    hint: 'Esc',
   },
   Backspace: {
     code: 8,
-    hint: '⌫',
+    hint: 'Backspace ⌫',
   },
   Tab: {
     code: 9,
-    hint: '⇥',
+    hint: 'Tab ⇥',
   },
   Enter: {
     code: 13,
-    hint: '↩',
+    hint: 'Enter ↩',
   },
   Shift: {
     code: 16,
-    hint: '⇧',
+    hint: 'Shift ⇧',
   },
   Control: {
     code: 17,
-    hint: 'control ⌃',
+    hint: 'Control ⌃',
   },
   Option: {
     code: 18,
-    hint: 'option ⌥',
+    hint: 'Option ⌥',
   },
   CapsLock: {
     code: 20,
-    hint: '⇪',
+    hint: 'Caps ⇪',
   },
   Command: {
     code: 91,
-    hint: '⌘',
+    hint: 'Command ⌘',
   },
   Space: {
     code: 32,
-    hint: '␣',
+    hint: 'Space ␣',
   },
   Left: {
     code: 37,
-    hint: '←',
+    hint: 'Left ←',
   },
   Up: {
     code: 38,
-    hint: '↑',
+    hint: 'Up ↑',
   },
   Right: {
     code: 39,
-    hint: '→',
+    hint: 'Right →',
   },
   Down: {
     code: 40,
-    hint: '↓',
+    hint: 'Down ↓',
   },
   Zero: {
     code: 48,

--- a/shared/@hedvig-ui/utils/platform.ts
+++ b/shared/@hedvig-ui/utils/platform.ts
@@ -1,0 +1,16 @@
+import { Key, Keys } from '@hedvig-ui/utils/key-press-hook'
+
+interface UsePlatformResult {
+  isMetaKey: (KeyBoardEvent) => boolean
+  metaKey: Key
+  platform: 'Mac' | 'Other'
+}
+
+export const usePlatform = (): UsePlatformResult => {
+  const isMac = window.navigator.appVersion.indexOf('Mac') !== -1
+  return {
+    isMetaKey: (e) => (isMac ? e.metaKey : e.ctrlKey),
+    metaKey: isMac ? Keys.Command : Keys.Control,
+    platform: isMac ? 'Mac' : 'Other',
+  }
+}

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -12,6 +12,11 @@ export interface Change {
 
 export const changelog: ReadonlyArray<Change> = [
   {
+    date: '2021-09-29',
+    change: 'Allows Windows user to send messages through Command + Enter',
+    authorGithubHandle: 'vonElfvin',
+  },
+  {
     date: '2021-09-22',
     change:
       'Chat messages not sent are saved as drafts, even if you change page 🎉',

--- a/src/features/claims/claim-details/components/ClaimNotes.tsx
+++ b/src/features/claims/claim-details/components/ClaimNotes.tsx
@@ -1,3 +1,4 @@
+import { usePlatform } from '@hedvig-ui/utils/platform'
 import { format, parseISO } from 'date-fns'
 import React, { useState } from 'react'
 import {
@@ -80,6 +81,7 @@ const ClaimNotes: React.FC<{ claimId: string; focus: boolean }> = ({
   } = useClaimPageQuery({
     variables: { claimId },
   })
+  const { isMetaKey, metaKey } = usePlatform()
   const notes = claimNotesData?.claim?.notes ?? []
   const events = claimNotesData?.claim?.events ?? []
 
@@ -171,7 +173,7 @@ const ClaimNotes: React.FC<{ claimId: string; focus: boolean }> = ({
         onBlur={() => setTextFieldFocused(false)}
         onKeyDown={(e) => {
           if (
-            e.metaKey &&
+            isMetaKey(e) &&
             e.keyCode === Keys.Enter.code &&
             !submitting &&
             note
@@ -188,8 +190,8 @@ const ClaimNotes: React.FC<{ claimId: string; focus: boolean }> = ({
         {textFieldFocused && (
           <FadeIn duration={200}>
             <NoteTip>
-              Press <Shadowed>Command</Shadowed> + <Shadowed>Enter</Shadowed> to
-              add note
+              Press <Shadowed>{metaKey.hint}</Shadowed> +{' '}
+              <Shadowed>Enter</Shadowed> to add note
             </NoteTip>
           </FadeIn>
         )}

--- a/src/features/conversations/chat/ConversationChat.tsx
+++ b/src/features/conversations/chat/ConversationChat.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import { FadeIn, Flex, Paragraph, Shadowed, TextArea } from '@hedvig-ui'
 import { Keys } from '@hedvig-ui/utils/key-press-hook'
+import { usePlatform } from '@hedvig-ui/utils/platform'
 import { useDraftMessage } from 'features/member/messages/hooks/use-draft-message'
 import { MessagesList } from 'features/member/messages/MessagesList'
 import React, { useEffect, useState } from 'react'
@@ -46,13 +47,14 @@ export const ConversationChat: React.FC<{
   const [message, setMessage] = useState(draft)
   const [inputFocused, setInputFocused] = useState(false)
   const [sendMessage, { loading }] = useSendMessageMutation()
+  const { isMetaKey, metaKey } = usePlatform()
 
   useEffect(() => {
     setMessage(draft)
   }, [memberId])
 
-  const handleOnKeyPress = (e) => {
-    if (e.metaKey && e.charCode === Keys.Enter.code && !loading && message) {
+  const handleOnKeyDown = (e) => {
+    if (isMetaKey(e) && e.keyCode === Keys.Enter.code && !loading && message) {
       toast.promise(
         sendMessage({
           variables: {
@@ -98,21 +100,22 @@ export const ConversationChat: React.FC<{
               setDraft(value)
               setMessage(value)
             }}
-            onKeyPress={handleOnKeyPress}
+            onKeyDown={handleOnKeyDown}
           />
         </ConversationFooter>
       </ConversationContent>
       <Flex fullWidth justify={'space-between'} style={{ marginTop: '1.0em' }}>
         <FadeIn duration={200}>
           <Tip>
-            <Shadowed>Command</Shadowed> + <Shadowed>Shift</Shadowed> +{' '}
+            <Shadowed>{metaKey.hint}</Shadowed> + <Shadowed>Shift</Shadowed> +{' '}
             <Shadowed>Enter</Shadowed> to mark as resolved
           </Tip>
         </FadeIn>
         {inputFocused && (
           <FadeIn duration={200}>
             <Tip>
-              <Shadowed>Command</Shadowed> + <Shadowed>Enter</Shadowed> to send
+              <Shadowed>{metaKey.hint}</Shadowed> + <Shadowed>Enter</Shadowed>{' '}
+              to send
             </Tip>
           </FadeIn>
         )}

--- a/src/features/conversations/hooks/use-resolve-conversation.ts
+++ b/src/features/conversations/hooks/use-resolve-conversation.ts
@@ -1,4 +1,5 @@
 import { Keys, useKeyIsPressed } from '@hedvig-ui/utils/key-press-hook'
+import { usePlatform } from '@hedvig-ui/utils/platform'
 import { useEffect } from 'react'
 import { toast } from 'react-hot-toast'
 import {
@@ -10,6 +11,7 @@ export const useResolveConversation = (
   onResolve: () => void,
   memberId?: string,
 ) => {
+  const { metaKey } = usePlatform()
   const [markAsResolved, { loading }] = useMarkQuestionAsResolvedMutation({
     refetchQueries: [
       {
@@ -19,13 +21,13 @@ export const useResolveConversation = (
   })
 
   const isShiftPressed = useKeyIsPressed(Keys.Shift)
-  const isCommandPressed = useKeyIsPressed(Keys.Command)
+  const isMetaPressed = useKeyIsPressed(metaKey)
   const isEnterPressed = useKeyIsPressed(Keys.Enter)
 
   useEffect(() => {
     if (
       isShiftPressed &&
-      isCommandPressed &&
+      isMetaPressed &&
       isEnterPressed &&
       !loading &&
       memberId
@@ -47,5 +49,5 @@ export const useResolveConversation = (
         },
       )
     }
-  }, [isShiftPressed, isCommandPressed, isEnterPressed])
+  }, [isShiftPressed, isMetaPressed, isEnterPressed])
 }

--- a/src/features/member/chat/ChatPanel.tsx
+++ b/src/features/member/chat/ChatPanel.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import { Button, Checkbox, FadeIn, Flex, Shadowed, Spinner } from '@hedvig-ui'
 import { Keys, shouldIgnoreInput } from '@hedvig-ui/utils/key-press-hook'
+import { usePlatform } from '@hedvig-ui/utils/platform'
 import { useDraftMessage } from 'features/member/messages/hooks/use-draft-message'
 import { getSendMessageOptions, useSendMessage } from 'graphql/use-send-message'
 import React, { useState } from 'react'
@@ -95,6 +96,7 @@ export const ChatPanel = ({ memberId }) => {
   const [forceSendMessage, setForceSendMessage] = useState(false)
   const [sendMessage, { loading }] = useSendMessage()
   const [textFieldFocused, setTextFieldFocused] = useState(false)
+  const { isMetaKey, metaKey } = usePlatform()
 
   const handleInputChange = (e: any) => {
     const value = e.target.value
@@ -165,7 +167,11 @@ export const ChatPanel = ({ memberId }) => {
           onFocus={() => setTextFieldFocused(true)}
           onBlur={() => setTextFieldFocused(false)}
           onKeyDown={(e) => {
-            if (e.metaKey && e.keyCode === Keys.Enter.code && currentMessage) {
+            if (
+              isMetaKey(e) &&
+              e.keyCode === Keys.Enter.code &&
+              currentMessage
+            ) {
               handleSubmit()
             }
           }}
@@ -184,8 +190,8 @@ export const ChatPanel = ({ memberId }) => {
         {textFieldFocused && !loading && (
           <FadeIn duration={200}>
             <ChatTip>
-              Press <Shadowed>Command</Shadowed> + <Shadowed>Enter</Shadowed> to
-              send
+              Press <Shadowed>{metaKey.hint}</Shadowed> +{' '}
+              <Shadowed>Enter</Shadowed> to send
             </ChatTip>
           </FadeIn>
         )}

--- a/src/features/members-search/components/SearchForm.tsx
+++ b/src/features/members-search/components/SearchForm.tsx
@@ -1,5 +1,6 @@
 import { Checkbox, FadeIn, Shadowed } from '@hedvig-ui'
 import { Keys, shouldIgnoreInput } from '@hedvig-ui/utils/key-press-hook'
+import { usePlatform } from '@hedvig-ui/utils/platform'
 import {
   EscapeButton,
   Group,
@@ -36,6 +37,7 @@ export const SearchForm: React.FC<SearchFieldProps> = ({
   setLuckySearch,
 }) => {
   const [textFieldFocused, setTextFieldFocused] = useState(false)
+  const { isMetaKey, metaKey } = usePlatform()
 
   return (
     <form
@@ -71,7 +73,7 @@ export const SearchForm: React.FC<SearchFieldProps> = ({
             }}
             onBlur={() => setTextFieldFocused(false)}
             onKeyDown={(e) => {
-              if (e.metaKey && e.keyCode === Keys.Enter.code && query) {
+              if (isMetaKey(e) && e.keyCode === Keys.Enter.code && query) {
                 setLuckySearch(true)
                 onSubmit(query, includeAll)
               } else {
@@ -102,8 +104,8 @@ export const SearchForm: React.FC<SearchFieldProps> = ({
         {textFieldFocused && (
           <FadeIn duration={200}>
             <SearchTip>
-              Press <Shadowed>Command</Shadowed> + <Shadowed>Enter</Shadowed> to
-              use lucky search
+              Press <Shadowed>{metaKey.hint}</Shadowed> +{' '}
+              <Shadowed>Enter</Shadowed> to use lucky search
             </SearchTip>
           </FadeIn>
         )}


### PR DESCRIPTION
# Jira Issue: []

## What?
- Have different modifiers for Windows
- fix sending messages for Conversations
- Ignore Enter key if the input is empty

## Why?
- Command does not exist on Windows and the Windows key is not easy to use in Web it seems

## Optional screenshots

## Optional checklist
- [x] Updated `src/changelog.ts`
- [ ] Codescouted
- [ ] Unit tests written
- [x] Tested locally

