### PR TITLE
Create prototype of Input component

### DIFF
--- a/shared/@hedvig-ui/Form/form.tsx
+++ b/shared/@hedvig-ui/Form/form.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { Button, ButtonProps, CustomInputProps, Input, Label } from '@hedvig-ui'
+import { Button, ButtonProps, Input, InputProps, Label } from '@hedvig-ui'
 import { ErrorMessage } from '@hookform/error-message'
 import React, { useEffect, useRef } from 'react'
 import { Controller, RegisterOptions, useFormContext } from 'react-hook-form'
@@ -99,12 +99,10 @@ export const SubmitButton: React.FC<ButtonProps> = ({ children, ...props }) => {
   )
 }
 
-const FormInputComponent: React.FC<CustomInputProps & FormFieldProps> = ({
+const FormInputComponent: React.FC<InputProps & FormFieldProps> = ({
   name,
   rules,
   defaultValue,
-  affix,
-  affixPosition,
   ...props
 }) => {
   return (
@@ -112,19 +110,12 @@ const FormInputComponent: React.FC<CustomInputProps & FormFieldProps> = ({
       name={name}
       rules={rules}
       defaultValue={defaultValue}
-      as={
-        <Input
-          {...props}
-          label={affix}
-          labelPosition={affixPosition}
-          autoComplete="off"
-        />
-      }
+      as={<Input {...props} />}
     />
   )
 }
 
-export const FormInput: React.FC<CustomInputProps & FormFieldProps> = ({
+export const FormInput: React.FC<InputProps & FormFieldProps> = ({
   ...props
 }) => {
   return (

--- a/shared/@hedvig-ui/Input/input.stories.tsx
+++ b/shared/@hedvig-ui/Input/input.stories.tsx
@@ -1,5 +1,5 @@
 import { Input } from '@hedvig-ui'
-import { boolean } from '@storybook/addon-knobs'
+import { boolean, select } from '@storybook/addon-knobs'
 import React from 'react'
 
 export default {
@@ -8,14 +8,18 @@ export default {
 }
 
 export const StandardInput: React.FC = () => {
-  const [text, setText] = React.useState('')
+  const [text, setText] = React.useState<string>('')
+
   return (
     <>
       <Input
+        size={select('Size', ['small', 'medium', 'big'], 'medium')}
+        disabled={boolean('Disabled', false)}
+        loading={boolean('Loading', false)}
+        success={boolean('Successs', false)}
+        onChange={({ target: { value } }) => setText(value)}
+        error={boolean('Error', false)}
         placeholder="Write your life story here..."
-        value={text}
-        onChange={(_e, { value }) => setText(value)}
-        muted={boolean('Muted', false)}
       />
       <p>
         <strong>Written text:</strong> {text}

--- a/shared/@hedvig-ui/Input/input.stories.tsx
+++ b/shared/@hedvig-ui/Input/input.stories.tsx
@@ -1,6 +1,6 @@
 import { Input } from '@hedvig-ui'
 import { boolean, select } from '@storybook/addon-knobs'
-import React from 'react'
+import React, { useEffect } from 'react'
 
 export default {
   title: 'Input',
@@ -9,6 +9,12 @@ export default {
 
 export const StandardInput: React.FC = () => {
   const [text, setText] = React.useState<string>('')
+  const [affix, setAffix] = React.useState<boolean>(false)
+  const isAffix = boolean('Affix', false)
+
+  useEffect(() => {
+    setAffix(isAffix)
+  }, [isAffix])
 
   return (
     <>
@@ -20,6 +26,14 @@ export const StandardInput: React.FC = () => {
         onChange={({ target: { value } }) => setText(value)}
         error={boolean('Error', false)}
         placeholder="Write your life story here..."
+        style={{ marginBottom: 15 }}
+        affix={
+          affix
+            ? {
+                content: 'SEK',
+              }
+            : undefined
+        }
       />
       <p>
         <strong>Written text:</strong> {text}

--- a/shared/@hedvig-ui/Input/input.tsx
+++ b/shared/@hedvig-ui/Input/input.tsx
@@ -1,66 +1,182 @@
-import { css } from '@emotion/react'
+import { keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
-import { Keys, shouldIgnoreInput } from '@hedvig-ui/utils/key-press-hook'
-import { colorsV3, fonts } from '@hedviginsurance/brand'
 import React from 'react'
 import {
-  Input as SemanticInput,
-  InputProps,
-  LabelProps,
-} from 'semantic-ui-react'
+  ArrowRepeat,
+  CheckCircleFill,
+  ExclamationCircleFill,
+} from 'react-bootstrap-icons'
 
-export interface CustomInputProps extends InputProps {
-  muted?: boolean
-  affix?: LabelProps
-  affixPosition?: 'left' | 'right'
-}
+const rotate = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
 
-const StyledSemanticInput = styled(SemanticInput)<CustomInputProps>`
-  &&&& {
-    width: 100%;
-    input::-webkit-outer-spin-button,
-    input::-webkit-inner-spin-button {
-      -webkit-appearance: none;
-      margin: 0;
-    }
-    input {
-      font-family: ${fonts.FAVORIT};
-
-      transition: background 300ms, border-color 300ms;
-      ${({ muted, theme }) =>
-        muted
-          ? css`
-              background-color: ${theme.mutedBackground ?? colorsV3.gray300};
-              border-color: ${theme.mutedBackground ?? colorsV3.gray300};
-              color: ${theme.mutedText ?? colorsV3.gray500};
-            `
-          : css`
-              :focus {
-                border-color: ${theme.accent};
-              }
-            `}
-
+  to {
+    transform: rotate(360deg);
   }
 `
 
-export const Input: React.FC<CustomInputProps> = (props) => (
-  <StyledSemanticInput
-    {...props}
-    onKeyDown={(e) => {
-      if (shouldIgnoreInput(e.key)) {
-        e.preventDefault()
-        return
-      }
+export type InputSize = 'small' | 'medium' | 'big'
+const paddingSize = { small: '5px 10px', medium: '10px 15px', big: '15px 20px' }
+const fontSize = { small: '11px', medium: '14px', big: '18px' }
 
-      if (e.keyCode === Keys.Escape.code) {
-        e.preventDefault()
-        e.target.blur()
-        return
-      }
+const InputWrapper = styled.div`
+  width: 100%;
 
-      if (props.onKeyDown) {
-        props.onKeyDown(e)
-      }
-    }}
-  />
-)
+  position: relative;
+  display: flex;
+  align-items: center;
+`
+
+const InputStyled = styled.input<{
+  success?: boolean
+  error?: boolean
+  disabled?: boolean
+  muted?: boolean
+  loading?: boolean
+  inputSize?: InputSize
+  withIcon?: boolean
+}>`
+  transition: all 0.3s;
+
+  width: 100%;
+
+  padding: ${({ inputSize }) => paddingSize[inputSize || 'medium']};
+  ${({ withIcon }) => withIcon && 'padding-left: 55px;'}
+
+  border-radius: 0.25rem;
+  outline: none;
+  border: 1px solid
+    ${({ success, error, disabled, theme }) =>
+      success
+        ? theme.success
+        : error
+        ? theme.danger
+        : disabled
+        ? theme.placeholderColor
+        : theme.border};
+
+  ${({ muted }) => muted && 'border: none;'}
+
+  font-size: ${({ inputSize }) => fontSize[inputSize || 'medium']};
+  font-weight: bold;
+  color: ${({ disabled, theme }) =>
+    !disabled ? theme.foreground : theme.placeholderColor};
+  background-color: ${({ muted, theme }) =>
+    !muted ? theme.background : theme.accentBackground};
+
+  ${({ disabled, loading }) =>
+    (disabled || loading) &&
+    `
+  pointer-events: none;
+  user-focus: none;
+  user-modify: read-only;
+  user-select: none;
+  `}
+
+  &::placeholder {
+    color: ${({ theme }) => theme.placeholderColor};
+  }
+
+  &:focus {
+    border-color: ${({ theme }) => theme.borderStrong};
+
+    &::placeholder {
+      color: ${({ theme, muted }) => !muted && theme.semiStrongForeground};
+    }
+  }
+`
+
+const iconStyles = `
+  position: absolute;
+  right: 15px;
+`
+
+const SuccessIcon = styled(CheckCircleFill)`
+  ${iconStyles}
+  color: ${({ theme }) => theme.success};
+`
+
+const ErrorIcon = styled(ExclamationCircleFill)`
+  ${iconStyles}
+  color: ${({ theme }) => theme.danger};
+`
+
+const LoadingIcon = styled(ArrowRepeat)`
+  ${iconStyles}
+  animation: ${rotate} 2s linear infinite;
+`
+
+const CustomIcon = styled.div`
+  position: absolute;
+  left: 20px;
+
+  width: 20px;
+  height: 20px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  & * {
+    width: 100%;
+    height: 100%;
+  }
+`
+
+export interface InputProps {
+  autoFocus?: boolean
+  disabled?: boolean
+  error?: boolean
+  success?: boolean
+  muted?: boolean
+  placeholder?: string
+  value?: string | number
+  id?: string
+  type?: string
+  name?: string
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+  onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void
+  ref?: React.RefObject<HTMLInputElement>
+  onFocus?: (event: React.ChangeEvent<HTMLInputElement>) => void
+  onBlur?: (event: React.ChangeEvent<HTMLInputElement>) => void
+  style?: React.CSSProperties
+  size?: InputSize
+  loading?: boolean
+  icon?: React.ReactNode
+
+  // Add affix and ?rules?
+}
+
+export const Input: React.FC<InputProps> = ({
+  success,
+  error,
+  disabled,
+  loading,
+  muted,
+  icon,
+  size: inputSize,
+  ...props
+}) => {
+  return (
+    <InputWrapper>
+      {icon ? <CustomIcon>{icon}</CustomIcon> : null}
+      <InputStyled
+        className="input"
+        withIcon={Boolean(icon)}
+        inputSize={inputSize}
+        success={success}
+        error={error}
+        loading={loading}
+        muted={muted}
+        disabled={disabled}
+        placeholder={props.placeholder}
+        {...props}
+      />
+      {loading && <LoadingIcon />}
+      {success && !error && !loading && <SuccessIcon />}
+      {error && !success && !loading && <ErrorIcon />}
+    </InputWrapper>
+  )
+}

--- a/shared/@hedvig-ui/Input/input.tsx
+++ b/shared/@hedvig-ui/Input/input.tsx
@@ -1,11 +1,7 @@
 import { keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
 import React from 'react'
-import {
-  ArrowRepeat,
-  CheckCircleFill,
-  ExclamationCircleFill,
-} from 'react-bootstrap-icons'
+import { CheckCircleFill, ExclamationCircleFill } from 'react-bootstrap-icons'
 
 const rotate = keyframes`
   from {
@@ -20,6 +16,7 @@ const rotate = keyframes`
 export type InputSize = 'small' | 'medium' | 'big'
 const paddingSize = { small: '5px 10px', medium: '10px 15px', big: '15px 20px' }
 const fontSize = { small: '11px', medium: '14px', big: '18px' }
+const iconWidth = { small: '15px', medium: '20px', big: '30px' }
 
 const InputWrapper = styled.div`
   width: 100%;
@@ -88,24 +85,48 @@ const InputStyled = styled.input<{
   }
 `
 
-const iconStyles = `
+const iconStyles = (size?: InputSize, affix?: boolean) => `
+  height: 65%;
+  width: ${iconWidth[size || 'medium']};
   position: absolute;
-  right: 15px;
+  right: ${!affix ? '15px' : '75px'};
 `
 
-const SuccessIcon = styled(CheckCircleFill)`
-  ${iconStyles}
+const SuccessIcon = styled(CheckCircleFill)<{
+  inputSize?: InputSize
+  affix?: boolean
+}>`
+  ${({ inputSize, affix }) => iconStyles(inputSize, affix)}
   color: ${({ theme }) => theme.success};
 `
 
-const ErrorIcon = styled(ExclamationCircleFill)`
-  ${iconStyles}
+const ErrorIcon = styled(ExclamationCircleFill)<{
+  inputSize?: InputSize
+  affix?: boolean
+}>`
+  ${({ inputSize, affix }) => iconStyles(inputSize, affix)}
   color: ${({ theme }) => theme.danger};
 `
 
-const LoadingIcon = styled(ArrowRepeat)`
-  ${iconStyles}
-  animation: ${rotate} 2s linear infinite;
+const LoadingIcon = styled.div<{
+  inputSize?: InputSize
+  affix?: boolean
+}>`
+  ${({ inputSize, affix }) => iconStyles(inputSize, affix)}
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:after {
+    content: ' ';
+    display: block;
+    width: 90%;
+    height: 90%;
+    border-radius: 50%;
+    border: 3px solid #000;
+    border-color: #000 transparent #000 transparent;
+    animation: ${rotate} 1s linear infinite;
+  }
 `
 
 const CustomIcon = styled.div`
@@ -124,6 +145,34 @@ const CustomIcon = styled.div`
     height: 100%;
   }
 `
+
+const Affix = styled.div<{ inputSize?: InputSize }>`
+  font-size: 12px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  position: absolute;
+  right: ${({ inputSize }) => (inputSize === 'small' ? '3px' : '5px')};
+
+  border-radius: 0.25rem;
+  background-color: ${({ theme }) => theme.accentBackground};
+  border: 1px solid ${({ theme }) => theme.border};
+
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+
+  height: calc(
+    100% - ${({ inputSize }) => (inputSize === 'small' ? '6px' : '10px')}
+  );
+  width: 50px;
+`
+
+interface AffixType {
+  content: string
+}
 
 export interface InputProps {
   autoFocus?: boolean
@@ -145,8 +194,7 @@ export interface InputProps {
   size?: InputSize
   loading?: boolean
   icon?: React.ReactNode
-
-  // Add affix and ?rules?
+  affix?: AffixType
 }
 
 export const Input: React.FC<InputProps> = ({
@@ -157,10 +205,16 @@ export const Input: React.FC<InputProps> = ({
   muted,
   icon,
   size: inputSize,
+  affix,
+  style,
   ...props
 }) => {
+  const isAffix = affix && affix.content
+  const isSuccess = success && !error && !loading
+  const isError = error && !success && !loading
+
   return (
-    <InputWrapper>
+    <InputWrapper style={style}>
       {icon ? <CustomIcon>{icon}</CustomIcon> : null}
       <InputStyled
         className="input"
@@ -174,9 +228,14 @@ export const Input: React.FC<InputProps> = ({
         placeholder={props.placeholder}
         {...props}
       />
-      {loading && <LoadingIcon />}
-      {success && !error && !loading && <SuccessIcon />}
-      {error && !success && !loading && <ErrorIcon />}
+      {isAffix && <Affix inputSize={inputSize}>{affix.content}</Affix>}
+      {loading && (
+        <LoadingIcon affix={Boolean(isAffix)} inputSize={inputSize} />
+      )}
+      {isSuccess && (
+        <SuccessIcon affix={Boolean(isAffix)} inputSize={inputSize} />
+      )}
+      {isError && <ErrorIcon affix={Boolean(isAffix)} inputSize={inputSize} />}
     </InputWrapper>
   )
 }

--- a/shared/@hedvig-ui/index.ts
+++ b/shared/@hedvig-ui/index.ts
@@ -4,7 +4,7 @@ import { BadgeProps as _BadgeProps } from './Badge/badge'
 import { ButtonProps as _ButtonProps } from './Button/button'
 import { CardTitleBadgeProps as _CardTitleBadgeProps } from './Card/card'
 import { InfoTagStatus as _InfoTagStatus } from './InfoRow/info-row'
-import { CustomInputProps as _CustomInputProps } from './Input/input'
+import { InputProps as _InputProps } from './Input/input'
 import { ModalProps as _ModalProps } from './Modal'
 import { SpacingSize as _SpacingSize } from './Spacing/spacing'
 
@@ -60,7 +60,7 @@ export {
 } from './InfoRow/info-row'
 export type InfoTagStatus = _InfoTagStatus
 export { Input } from './Input/input'
-export type CustomInputProps = _CustomInputProps
+export type InputProps = _InputProps
 export { JsonSchemaForm } from './JsonSchemaForm/json-schema-form'
 export { List, ListItem } from './List/list'
 export { Loadable } from './Loadable/loadable'

--- a/shared/@hedvig-ui/utils/command-line-hook.tsx
+++ b/shared/@hedvig-ui/utils/command-line-hook.tsx
@@ -8,7 +8,7 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import { Icon } from 'semantic-ui-react'
+import { Search as SearchIcon } from 'react-bootstrap-icons'
 
 const CommandLineWindow = styled.div`
   position: absolute;
@@ -192,11 +192,8 @@ export const CommandLineComponent: React.FC<{
 
             setSearchValue(inputValue)
           }}
-          icon={<Icon name="search" style={{ marginLeft: '1em' }} />}
-          iconPosition="left"
+          icon={<SearchIcon name="search" />}
           placeholder="What can I help you with?"
-          transparent
-          size="large"
         />
       </SearchWrapper>
       <SearchResultWrapper>

--- a/src/features/claims/claim-details/components/ClaimPayments/ClaimPayment.tsx
+++ b/src/features/claims/claim-details/components/ClaimPayments/ClaimPayment.tsx
@@ -140,6 +140,7 @@ export const ClaimPayment: React.FC<{
           name="amount"
           defaultValue=""
           type="number"
+          affix={{ content: 'SEK' }}
           rules={{
             required: 'Amount is required',
             pattern: {

--- a/src/features/claims/claim-details/components/ClaimPayments/ClaimPayment.tsx
+++ b/src/features/claims/claim-details/components/ClaimPayments/ClaimPayment.tsx
@@ -140,11 +140,6 @@ export const ClaimPayment: React.FC<{
           name="amount"
           defaultValue=""
           type="number"
-          affix={{
-            content: 'SEK',
-            basic: true,
-          }}
-          affixPosition="right"
           rules={{
             required: 'Amount is required',
             pattern: {

--- a/src/features/member/tabs/campaigns-tab/campaigns/CampaignCodeInput.tsx
+++ b/src/features/member/tabs/campaigns-tab/campaigns/CampaignCodeInput.tsx
@@ -19,7 +19,7 @@ export const CampaignCodeInput: React.FC<{
         <Input
           placeholder="Campaign code"
           value={campaignCode}
-          onChange={(_e, { value }) => {
+          onChange={({ target: { value } }) => {
             setCampaignCode(value)
           }}
         />

--- a/src/features/member/tabs/quote-tab/QuotePrice.tsx
+++ b/src/features/member/tabs/quote-tab/QuotePrice.tsx
@@ -41,12 +41,12 @@ interface Props {
 
 export const QuotePrice = ({ quote }: Props) => {
   const [editPrice, setEditPrice] = useState(false)
-  const [newPrice, setNewPrice] = useState(quote.price)
+  const [newPrice, setNewPrice] = useState<number>(quote.price || 0)
   const [overrideQuotePrice] = useOverrideQuotePriceMutation()
   const { confirm } = useConfirmDialog()
 
   const onPriceChange = (e) => setNewPrice(e.target.value)
-  const restorePrice = () => setNewPrice(quote.price)
+  const restorePrice = () => setNewPrice(quote.price || 0)
 
   const onCancel = () => {
     restorePrice()

--- a/src/features/members-search/components/SearchForm.tsx
+++ b/src/features/members-search/components/SearchForm.tsx
@@ -50,7 +50,6 @@ export const SearchForm: React.FC<SearchFieldProps> = ({
     >
       <Group>
         <SearchInputGroup>
-          <SearchIcon muted={!query} />
           <SearchInput
             style={{ borderRadius: '0.5rem' }}
             onChange={({ target: { value } }) => {

--- a/src/features/members-search/components/SearchForm.tsx
+++ b/src/features/members-search/components/SearchForm.tsx
@@ -20,7 +20,7 @@ interface SearchFieldProps {
   setQuery: (query: string) => void
   setIncludeAll: (includeAll: boolean) => void
   currentResultSize: number
-  searchFieldRef: React.Ref<any>
+  searchFieldRef: React.RefObject<HTMLInputElement>
   setLuckySearch: (luckySearch: boolean) => void
 }
 
@@ -52,12 +52,14 @@ export const SearchForm: React.FC<SearchFieldProps> = ({
         <SearchInputGroup>
           <SearchIcon muted={!query} />
           <SearchInput
-            onChange={(_, { value }) => {
+            style={{ borderRadius: '0.5rem' }}
+            onChange={({ target: { value } }) => {
               if (shouldIgnoreInput(value)) {
                 return
               }
               setQuery(value)
             }}
+            icon={<SearchIcon muted={!query} />}
             placeholder="Looking for someone...?"
             id="query"
             value={query}

--- a/src/features/members-search/styles.tsx
+++ b/src/features/members-search/styles.tsx
@@ -65,28 +65,14 @@ export const SearchInputGroup = styled('div')({
 })
 export const SearchIcon = styled(SearchBootstrapIcon)<{ muted: boolean }>(
   ({ muted, theme }) => ({
-    position: 'absolute',
-    top: '50%',
-    left: '1rem',
-    transform: 'translateY(-50%)',
+    transform: 'translateY(-1.5px)',
     zIndex: 1,
     fill: muted ? theme.mutedText : undefined,
     transition: 'fill 300ms',
   }),
 )
 
-export const SearchInput = styled(Input)({
-  marginRight: '1rem',
-
-  '&&': {
-    width: '100%',
-  },
-
-  '&& input': {
-    borderRadius: '0.5rem',
-    paddingLeft: '3rem',
-  },
-})
+export const SearchInput = styled(Input)({})
 
 export const EscapeButton = styled(Button)<{ visible: boolean }>(
   ({ visible }) => ({

--- a/src/features/tools/claim-types/forms/CreateOptionForm.tsx
+++ b/src/features/tools/claim-types/forms/CreateOptionForm.tsx
@@ -73,7 +73,6 @@ export const CreateOptionForm: React.FC<{}> = () => {
           onChange={(e) => {
             setNewOptionName(e.currentTarget.value)
           }}
-          style={{ width: '100%' }}
         />
         <Spacing top={'small'} />
         <Button

--- a/src/features/tools/claim-types/forms/CreatePropertyForm.tsx
+++ b/src/features/tools/claim-types/forms/CreatePropertyForm.tsx
@@ -70,7 +70,6 @@ export const CreatePropertyForm: React.FC<{}> = () => {
           onChange={(e) => {
             setNewPropertyName(e.currentTarget.value)
           }}
-          style={{ width: '100%' }}
         />
         <Spacing top={'small'} />
         <Button

--- a/src/features/tools/switcher-automation/SwitcherTableRow.tsx
+++ b/src/features/tools/switcher-automation/SwitcherTableRow.tsx
@@ -115,7 +115,7 @@ export const SwitcherEmailRow: React.FC<Pick<
   })
 
   const [editNote, setEditNote] = useState(false)
-  const [newNote, setNewNote] = useState(note)
+  const [newNote, setNewNote] = useState<string>(note || '')
 
   const [activeFrom, setActiveFrom] = useState(new Date())
   const [activateContractView, setActivateContractView] = useState(false)
@@ -168,13 +168,15 @@ export const SwitcherEmailRow: React.FC<Pick<
         {editNote ? (
           <>
             <Input
-              autofocus
+              autoFocus
               value={newNote}
               onChange={(e) => setNewNote(e.target.value)}
               onKeyDown={(e) => {
                 if (e.keyCode === Keys.Escape.code) {
-                  setEditNote(false)
-                  setNewNote(note)
+                  if (note) {
+                    setEditNote(false)
+                    setNewNote(note || '')
+                  }
                   return
                 }
                 if (e.keyCode !== Keys.Enter.code) {

--- a/src/pages/tools/UnsignMemberPage.tsx
+++ b/src/pages/tools/UnsignMemberPage.tsx
@@ -14,7 +14,7 @@ export const UnsignMemberPage: React.FC = () => {
       <MainHeadline>Unsign member</MainHeadline>
       <Input
         value={ssn}
-        onChange={(_e, { value }) => {
+        onChange={({ target: { value } }) => {
           setSsn(value)
         }}
         placeholder="Social Security Number"


### PR DESCRIPTION
# Jira Issue: [IP-92](https://hedvig.atlassian.net/jira/software/projects/IP/boards/19?selectedIssue=IP-92)

## What?
Create input component without semantic-ui
It's first prototype of new Inputs without Semantic-UI and I will refactor it! I just want to know if I need to add something or do something else.
I'm not sure if this **loader** is good solution. Have else ideas which we can use?

## Why?
For more clear using components with refs and other. And for less external libraries

## Videos

https://user-images.githubusercontent.com/89198006/135800781-975b1bb4-ae09-46df-91cc-5ecbc687ad77.mov


https://user-images.githubusercontent.com/89198006/135800796-b1d1a3c2-7653-4e9f-94a3-5f84a50c37a6.mov



## Optional checklist
- [ ] Updated `src/changelog.ts`
- [ ] Codescouted
- [ ] Unit tests written
- [ ] Tested locally

