### PR TITLE
Add warning when editing dates on agreements if it affects another

### DIFF
--- a/src/features/member/tabs/contracts-tab/agreement/FromDate.tsx
+++ b/src/features/member/tabs/contracts-tab/agreement/FromDate.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled'
 import {
   Button,
   ButtonsGroup,
@@ -9,7 +8,7 @@ import {
   ThirdLevelHeadline,
 } from '@hedvig-ui'
 import { useConfirmDialog } from '@hedvig-ui/utils/modal-hook'
-import { differenceInDays, format, subDays } from 'date-fns'
+import { format, subDays } from 'date-fns'
 import {
   changeFromDateOptions,
   useChangeFromDate,
@@ -17,6 +16,13 @@ import {
 import React from 'react'
 import { toast } from 'react-hot-toast'
 import { Contract, GenericAgreement } from 'types/generated/graphql'
+import {
+  checkGapBetweenAgreements,
+  DateSpan,
+  DialogWarning,
+  formatDate,
+  getDaysBetweenAgreements,
+} from './helpers'
 
 const initialFromDate = (agreement: GenericAgreement): Date =>
   agreement.fromDate ? new Date(agreement.fromDate) : new Date()
@@ -31,17 +37,6 @@ const getPreviousAgreement = (agreements, selectedAgreement) =>
     }
     return previousAgreement
   }, null)
-
-const DialogWarning = styled.span`
-  margin-top: 1rem;
-  display: block;
-  color: ${({ theme }) => theme.danger};
-`
-
-const DateSpan = styled.span`
-  font-weight: bold;
-  white-space: nowrap;
-`
 
 export const FromDate: React.FC<{
   agreement: GenericAgreement
@@ -58,7 +53,7 @@ export const FromDate: React.FC<{
   }
 
   const onConfirm = () => {
-    const formattedFromDate = format(fromDate, 'yyyy-MM-dd')
+    const formattedFromDate = formatDate(fromDate)
     let confirmText = (
       <>
         Do you wish to change from date to{' '}
@@ -70,15 +65,8 @@ export const FromDate: React.FC<{
       agreement,
     )
     if (previousAgreement) {
-      const daysBetweenAgreements = differenceInDays(
-        new Date(agreement.fromDate),
-        new Date(previousAgreement.toDate),
-      )
-      if (daysBetweenAgreements <= 1) {
-        const formattedPreviousToDate = format(
-          subDays(fromDate, 1),
-          'yyyy-MM-dd',
-        )
+      if (checkGapBetweenAgreements(previousAgreement, agreement)) {
+        const formattedPreviousToDate = formatDate(subDays(fromDate, 1))
         confirmText = (
           <>
             {confirmText}

--- a/src/features/member/tabs/contracts-tab/agreement/FromDate.tsx
+++ b/src/features/member/tabs/contracts-tab/agreement/FromDate.tsx
@@ -8,7 +8,7 @@ import {
   ThirdLevelHeadline,
 } from '@hedvig-ui'
 import { useConfirmDialog } from '@hedvig-ui/utils/modal-hook'
-import { format, subDays } from 'date-fns'
+import { subDays } from 'date-fns'
 import {
   changeFromDateOptions,
   useChangeFromDate,
@@ -21,7 +21,6 @@ import {
   DateSpan,
   DialogWarning,
   formatDate,
-  getDaysBetweenAgreements,
 } from './helpers'
 
 const initialFromDate = (agreement: GenericAgreement): Date =>
@@ -105,7 +104,7 @@ export const FromDate: React.FC<{
           <Spacing bottom width="auto">
             <FourthLevelHeadline>
               {agreement.fromDate !== null
-                ? format(new Date(agreement.fromDate), 'yyyy-MM-dd')
+                ? formatDate(new Date(agreement.fromDate))
                 : 'Not set'}
             </FourthLevelHeadline>
           </Spacing>

--- a/src/features/member/tabs/contracts-tab/agreement/FromDate.tsx
+++ b/src/features/member/tabs/contracts-tab/agreement/FromDate.tsx
@@ -9,8 +9,7 @@ import {
   ThirdLevelHeadline,
 } from '@hedvig-ui'
 import { useConfirmDialog } from '@hedvig-ui/utils/modal-hook'
-import { format, subDays } from 'date-fns'
-import differenceInDays from 'date-fns/differenceInDays'
+import { differenceInDays, format, subDays } from 'date-fns'
 import {
   changeFromDateOptions,
   useChangeFromDate,

--- a/src/features/member/tabs/contracts-tab/agreement/ToDate.tsx
+++ b/src/features/member/tabs/contracts-tab/agreement/ToDate.tsx
@@ -8,7 +8,7 @@ import {
   ThirdLevelHeadline,
 } from '@hedvig-ui'
 import { useConfirmDialog } from '@hedvig-ui/utils/modal-hook'
-import { addDays, differenceInDays, format } from 'date-fns'
+import { addDays } from 'date-fns'
 import {
   changeToDateOptions,
   useChangeToDate,
@@ -21,7 +21,6 @@ import {
   DateSpan,
   DialogWarning,
   formatDate,
-  getDaysBetweenAgreements,
 } from './helpers'
 
 const initialToDate = (agreement: GenericAgreement): Date =>
@@ -101,7 +100,7 @@ export const ToDate: React.FC<{
         <Spacing bottom width="auto">
           <FourthLevelHeadline>
             {agreement.toDate !== null
-              ? format(new Date(agreement.toDate), 'yyyy-MM-dd')
+              ? formatDate(new Date(agreement.toDate))
               : 'Active'}
           </FourthLevelHeadline>
         </Spacing>

--- a/src/features/member/tabs/contracts-tab/agreement/ToDate.tsx
+++ b/src/features/member/tabs/contracts-tab/agreement/ToDate.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled'
 import {
   Button,
   ButtonsGroup,
@@ -17,6 +16,13 @@ import {
 import React from 'react'
 import { toast } from 'react-hot-toast'
 import { Contract, GenericAgreement } from 'types/generated/graphql'
+import {
+  checkGapBetweenAgreements,
+  DateSpan,
+  DialogWarning,
+  formatDate,
+  getDaysBetweenAgreements,
+} from './helpers'
 
 const initialToDate = (agreement: GenericAgreement): Date =>
   agreement.toDate ? new Date(agreement.toDate) : new Date()
@@ -32,16 +38,6 @@ const getNextAgreement = (agreements, selectedAgreement) =>
     return nextAgreement
   }, null)
 
-const DialogWarning = styled.span`
-  margin-top: 1rem;
-  display: block;
-  color: ${({ theme }) => theme.danger};
-`
-
-const DateSpan = styled.span`
-  font-weight: bold;
-  white-space: nowrap;
-`
 export const ToDate: React.FC<{
   agreement: GenericAgreement
   contract: Contract
@@ -61,7 +57,7 @@ export const ToDate: React.FC<{
   }, [agreement])
 
   const onConfirm = () => {
-    const formattedToDate = format(toDate, 'yyyy-MM-dd')
+    const formattedToDate = formatDate(toDate)
     let confirmText = (
       <>
         Do you wish to change the to date to{' '}
@@ -73,12 +69,8 @@ export const ToDate: React.FC<{
       agreement,
     )
     if (nextAgreement) {
-      const daysBetweenAgreements = differenceInDays(
-        new Date(nextAgreement.fromDate),
-        new Date(agreement.toDate),
-      )
-      if (daysBetweenAgreements <= 1) {
-        const formattedNextFromDate = format(addDays(toDate, 1), 'yyyy-MM-dd')
+      if (checkGapBetweenAgreements(agreement, nextAgreement)) {
+        const formattedNextFromDate = formatDate(addDays(toDate, 1))
         confirmText = (
           <>
             {confirmText}

--- a/src/features/member/tabs/contracts-tab/agreement/helpers.ts
+++ b/src/features/member/tabs/contracts-tab/agreement/helpers.ts
@@ -1,0 +1,21 @@
+import styled from '@emotion/styled'
+import { differenceInDays, format } from 'date-fns'
+
+export const DialogWarning = styled.span`
+  margin-top: 1rem;
+  display: block;
+  color: ${({ theme }) => theme.danger};
+`
+
+export const DateSpan = styled.span`
+  font-weight: bold;
+  white-space: nowrap;
+`
+
+export const checkGapBetweenAgreements = (previousAgreement, nextAgreement) =>
+  differenceInDays(
+    new Date(nextAgreement.fromDate),
+    new Date(previousAgreement.toDate),
+  ) <= 1
+
+export const formatDate = (date) => format(date, 'yyyy-MM-dd')


### PR DESCRIPTION
# Jira Issue: [IPC-295]

## What?
- Add a warning when changing a from/to-date on an agreement if it affects previous/next agreement
- If there is a gap between agreements already, do nothing

## Why?
- To prevent gaps between agreements when changing to/from dates, we also change connecting agreements from/to date to the day before/after

## Optional screenshots
![image](https://user-images.githubusercontent.com/4789631/136026688-7a2d17dc-0acd-4bec-a2db-3a2402373a30.png)

## Optional checklist
- [ ] Updated `src/changelog.ts`
- [x] Codescouted
- [ ] Unit tests written
- [X] Tested locally



[IPC-295]: https://hedvig.atlassian.net/browse/IPC-295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ