### PR TITLE
Feature: Add ability to copy only member Id

### DIFF
--- a/src/features/member/index.tsx
+++ b/src/features/member/index.tsx
@@ -15,6 +15,7 @@ import {
 import { useMemberHistory } from 'features/user/hooks/use-member-history'
 import { useNumberMemberGroups } from 'features/user/hooks/use-number-member-groups'
 import React, { useEffect } from 'react'
+import { Clipboard } from 'react-bootstrap-icons'
 import { Route, RouteComponentProps, useHistory } from 'react-router'
 import { Member } from 'types/generated/graphql'
 
@@ -22,6 +23,12 @@ const MemberPageWrapper = styled('div')({
   display: 'flex',
   flexDirection: 'row',
 })
+
+const CopyIcon = styled(Clipboard)`
+  height: 15px;
+  width: 15px;
+  cursor: pointer;
+`
 
 const MemberPageContainer = styled('div')`
   display: flex;
@@ -60,6 +67,8 @@ const Flag = styled('div')`
 `
 
 const MemberDetails = styled.div`
+  display: flex;
+  align-items: center;
   color: ${({ theme }) => theme.mutedText};
   padding-bottom: 4rem;
 `
@@ -137,7 +146,7 @@ export const MemberTabs: React.FC<RouteComponentProps<{
               {member.phoneNumber}
             </MemberDetailLink>
           )}
-          <Popover contents="Click to copy">
+          <Popover contents="Click to copy Link">
             <MemberDetailLink
               href={`${window.location.protocol}//${window.location.host}${history.location.pathname}`}
               onClick={(e) => {
@@ -153,8 +162,18 @@ export const MemberTabs: React.FC<RouteComponentProps<{
               {memberId}
             </MemberDetailLink>
           </Popover>
+          <Popover contents="Click to copy Id">
+            <CopyIcon
+              onClick={() => {
+                copy(memberId, {
+                  format: 'text/plain',
+                })
+              }}
+            />
+          </Popover>
+
           {member?.pickedLocale && (
-            <MemberDetail>
+            <MemberDetail style={{ paddingLeft: '1rem' }}>
               Language: {PickedLocaleFlag[member.pickedLocale]}
             </MemberDetail>
           )}


### PR DESCRIPTION
# Jira Issue: [IP-139](https://hedvig.atlassian.net/jira/software/projects/IP/boards/19?selectedIssue=IP-139)

## What?
Add Copy icon for copying only Member Id

## Why?
For comfortable copying of Member Id. 
It isn't convenient to get member id from full link of page

## Video
https://user-images.githubusercontent.com/89198006/139793919-4229aacb-8a87-4003-a7e8-33c6cbdd0687.mov

## Optional checklist
- [ ] Updated `src/changelog.ts`
- [ ] Codescouted
- [ ] Unit tests written
- [ ] Tested locally

