### PR TITLE
Fix: Set rendering of UserPanel only if visible

### DIFF
--- a/src/features/navigation/topbar/TopBar.tsx
+++ b/src/features/navigation/topbar/TopBar.tsx
@@ -84,6 +84,7 @@ const NotificationsButton: React.FC<{ onClick: () => void }> = ({
 
 export const TopBar = () => {
   const [showUsers, setShowUsers] = useState(false)
+  const [closingUsers, setClosingUsers] = useState(false)
   const [showUserNotifications, setShowUserNotifications] = useState(false)
   const [showShareModal, setShowShareModal] = useState(false)
   const isEscapePressed = useKeyIsPressed(Keys.Escape)
@@ -93,6 +94,14 @@ export const TopBar = () => {
       setShowUsers(false)
     }
   }, [isEscapePressed])
+
+  const closeUsersHandler = () => {
+    setClosingUsers(true)
+    setTimeout(() => {
+      setShowUsers(false)
+      setClosingUsers(false)
+    }, 350)
+  }
 
   return (
     <Wrapper>
@@ -109,12 +118,11 @@ export const TopBar = () => {
         <ShareModal onClose={() => setShowShareModal(false)} />
       )}
 
-      <UserPanel
-        visible={showUsers}
-        onClickOutside={() => setShowUsers(false)}
-      />
+      {showUsers && (
+        <UserPanel closing={closingUsers} onClickOutside={closeUsersHandler} />
+      )}
       <TopBarContainer
-        pushLeft={showUsers}
+        pushLeft={showUsers && !closingUsers}
         direction="row"
         justify="flex-end"
         align="center"

--- a/src/features/user/UserPanel.tsx
+++ b/src/features/user/UserPanel.tsx
@@ -163,8 +163,6 @@ export const UserPanel: React.FC<{
 
   useClickOutside(panelRef, onClickOutside)
 
-  console.log(data)
-
   useEffect(() => {
     startPolling(1000)
     return () => stopPolling()


### PR DESCRIPTION
## What?
Set rendering of UserPanel only if its visible.

## Why?
For less rerenders of it even if its hidden. 

## Optional checklist
- [ ] Updated `src/changelog.ts`
- [ ] Codescouted
- [ ] Unit tests written
- [ ] Tested locally

