### PR TITLE
Feature: Track shortcuts & keyboard navigation

### DIFF
--- a/shared/@hedvig-ui/hooks/keyboard/use-vertical-keyboard-navigation.ts
+++ b/shared/@hedvig-ui/hooks/keyboard/use-vertical-keyboard-navigation.ts
@@ -3,6 +3,7 @@ import {
   useKeyboardListener,
   UseVerticalKeyboardNavigationProps,
 } from '@hedvig-ui/hooks/keyboard/use-keyboard-listener'
+import { PushKeyboardNavigation } from 'features/tracking/utils/tags'
 import { Dispatch, SetStateAction, useEffect, useState } from 'react'
 
 const handleStepChange = (
@@ -39,6 +40,7 @@ export const useVerticalKeyboardNavigation = ({
     ) {
       e.preventDefault()
       onPerformNavigation(navigationIndex)
+      PushKeyboardNavigation('useVerticalKeyboardNavigation', [Keys.Enter.code])
       return
     }
 
@@ -48,12 +50,14 @@ export const useVerticalKeyboardNavigation = ({
         onExit()
       }
       handleStepChange(setNavigationIndex, (i) => i > -1, -1)
+      PushKeyboardNavigation('useVerticalKeyboardNavigation', [Keys.Up.code])
       return
     }
 
     if (isPressing(e, Keys.Down)) {
       e.preventDefault()
       handleStepChange(setNavigationIndex, (i) => i < maxStep, 1)
+      PushKeyboardNavigation('useVerticalKeyboardNavigation', [Keys.Down.code])
       return
     }
   })

--- a/src/features/commands/use-command-line.tsx
+++ b/src/features/commands/use-command-line.tsx
@@ -5,6 +5,7 @@ import {
   useKeyIsPressed,
 } from '@hedvig-ui/hooks/keyboard/use-key-is-pressed'
 import { CommandLineModal } from 'features/commands/components/CommandLineModal'
+import { PushShortcutUsed } from 'features/tracking/utils/tags'
 import React, {
   createContext,
   useContext,
@@ -114,6 +115,11 @@ export const CommandLineProvider: React.FC = ({ children }) => {
     })
 
     if (matchIndex > -1) {
+      PushShortcutUsed(
+        actions.current[matchIndex].label,
+        actions.current[matchIndex].keys?.map((key) => key.code) ?? [],
+      )
+
       actions.current[matchIndex].onResolve()
       setShowCommandLine(false)
     }

--- a/src/features/tracking/utils/tags.ts
+++ b/src/features/tracking/utils/tags.ts
@@ -8,3 +8,12 @@ export const PushShortcutUsed = (name: string, keys: string[]) =>
       shortcutKeys: keys,
     },
   })
+
+export const PushKeyboardNavigation = (name: string, keys: string[]) =>
+  TagManager.dataLayer({
+    dataLayer: {
+      event: 'keyboard_navigation',
+      keyboardNavigationName: name,
+      keyboardNavigationKeys: keys,
+    },
+  })

--- a/src/features/tracking/utils/tags.ts
+++ b/src/features/tracking/utils/tags.ts
@@ -1,0 +1,10 @@
+import TagManager from 'react-gtm-module'
+
+export const PushShortcutUsed = (name: string, keys: string[]) =>
+  TagManager.dataLayer({
+    dataLayer: {
+      event: 'shortcut_used',
+      shortcutName: name,
+      shortcutKeys: keys,
+    },
+  })


### PR DESCRIPTION
This is just to get the basics in place, will update when the new keyboard navigation feature is implemented. As previously discussed, it also makes sense to track whether the same things are done but using clicks - will look into this further in another PR.

## What?
- Add tracking of `shortcut_used` (e.g. Alt + E to copy member e-mail)
- Add tracking of `keyboard_navigation` (e.g. arrow keys and pressing enter in a table)

## Why?
- Collect how these features are being used
