### PR TITLE
Fix: Hide datepicker if automatic payment

### DIFF
--- a/src/portals/hope/features/claims/claim-details/ClaimPayments/ClaimPayment.tsx
+++ b/src/portals/hope/features/claims/claim-details/ClaimPayments/ClaimPayment.tsx
@@ -124,7 +124,9 @@ export const ClaimPayment: React.FC<{
       exGratia: isExGratia,
       carrier,
       paidAt:
-        form.getValues().type !== ClaimPaymentType.Automatic ? date : null,
+        form.getValues().type !== ClaimPaymentType.Automatic
+          ? `${date}T00:00:00.000Z`
+          : null,
     }
 
     if (form.getValues().type === 'AutomaticSwish') {

--- a/src/portals/hope/features/claims/claim-details/ClaimPayments/ClaimPayment.tsx
+++ b/src/portals/hope/features/claims/claim-details/ClaimPayments/ClaimPayment.tsx
@@ -124,7 +124,10 @@ export const ClaimPayment: React.FC<{
       exGratia: isExGratia,
       carrier,
       paidAt:
-        form.getValues().type !== ClaimPaymentType.Automatic ? date : null,
+        form.getValues().type !== ClaimPaymentType.Automatic &&
+        form.getValues().type !== ClaimPaymentType.Expense
+          ? date
+          : null,
     }
 
     if (form.getValues().type === 'AutomaticSwish') {
@@ -267,6 +270,7 @@ export const ClaimPayment: React.FC<{
         )}
 
         {form.watch('type') !== ClaimPaymentType.Automatic &&
+          form.watch('type') !== ClaimPaymentType.Expense &&
           form.watch('type') !== undefined && (
             <TextDatePicker
               style={{ marginBottom: '2rem' }}

--- a/src/portals/hope/features/claims/claim-details/ClaimPayments/ClaimPayment.tsx
+++ b/src/portals/hope/features/claims/claim-details/ClaimPayments/ClaimPayment.tsx
@@ -124,10 +124,7 @@ export const ClaimPayment: React.FC<{
       exGratia: isExGratia,
       carrier,
       paidAt:
-        form.getValues().type !== ClaimPaymentType.Automatic &&
-        form.getValues().type !== ClaimPaymentType.Expense
-          ? date
-          : null,
+        form.getValues().type !== ClaimPaymentType.Automatic ? date : null,
     }
 
     if (form.getValues().type === 'AutomaticSwish') {
@@ -270,7 +267,6 @@ export const ClaimPayment: React.FC<{
         )}
 
         {form.watch('type') !== ClaimPaymentType.Automatic &&
-          form.watch('type') !== ClaimPaymentType.Expense &&
           form.watch('type') !== undefined && (
             <TextDatePicker
               style={{ marginBottom: '2rem' }}

--- a/src/portals/hope/features/claims/claim-details/ClaimPayments/ClaimPayment.tsx
+++ b/src/portals/hope/features/claims/claim-details/ClaimPayments/ClaimPayment.tsx
@@ -123,7 +123,8 @@ export const ClaimPayment: React.FC<{
       note: form.getValues().note,
       exGratia: isExGratia,
       carrier,
-      paidAt: date,
+      paidAt:
+        form.getValues().type !== ClaimPaymentType.Automatic ? date : null,
     }
 
     if (form.getValues().type === 'AutomaticSwish') {
@@ -265,12 +266,15 @@ export const ClaimPayment: React.FC<{
           </>
         )}
 
-        <TextDatePicker
-          style={{ marginBottom: '2rem' }}
-          placeholder="Payment performed"
-          value={date}
-          onChange={setDate}
-        />
+        {form.watch('type') !== ClaimPaymentType.Automatic &&
+          form.watch('type') !== undefined && (
+            <TextDatePicker
+              style={{ marginBottom: '2rem' }}
+              placeholder="Payment performed"
+              value={date}
+              onChange={setDate}
+            />
+          )}
 
         <div>
           <SubmitButton>Create payment</SubmitButton>


### PR DESCRIPTION
# Jira Issue: []

## What?
In the payment form on Claims View page hide DatePicker if automatic or expense option is selected.

## Optional checklist
- [ ] Updated `src/changelog.ts`
- [ ] Codescouted
- [ ] Unit tests written
- [ ] Tested locally

