### PR TITLE
Feature: Portals

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -86,6 +86,7 @@ type Me {
   role: String!
   user: User!
   settings(filters: UserSettingsFilter): [UserSetting!]!
+  portal: String!
 }
 
 input UserSettingsFilter {
@@ -472,7 +473,7 @@ enum ContractStatus {
 
 type TermsAndConditions {
   commencementDate: LocalDate!
-  displayName: String!
+  displayName: String!,
   url: String!
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -87,6 +87,7 @@ type Me {
   user: User!
   settings(filters: UserSettingsFilter): [UserSetting!]!
   portal: String!
+  availablePortals: [String!]!
 }
 
 input UserSettingsFilter {
@@ -142,8 +143,8 @@ type UserSetting {
 
 type MutationType {
   chargeMember(
-    id: ID!,
-    amount: MonetaryAmount!,
+    id: ID!
+    amount: MonetaryAmount!
     allowManualCharge: Boolean
   ): Member
   addAccountEntryToMember(
@@ -475,7 +476,7 @@ enum ContractStatus {
 
 type TermsAndConditions {
   commencementDate: LocalDate!
-  displayName: String!,
+  displayName: String!
   url: String!
 }
 
@@ -642,7 +643,7 @@ type UnknownIncentive {
 }
 
 union Incentive =
-  MonthlyPercentageDiscountFixedPeriod
+    MonthlyPercentageDiscountFixedPeriod
   | FreeMonths
   | CostDeduction
   | NoDiscount

--- a/schema.graphql
+++ b/schema.graphql
@@ -142,8 +142,8 @@ type UserSetting {
 
 type MutationType {
   chargeMember(
-    id: ID!
-    amount: MonetaryAmount!
+    id: ID!,
+    amount: MonetaryAmount!,
     allowManualCharge: Boolean
   ): Member
   addAccountEntryToMember(
@@ -294,6 +294,8 @@ type MutationType {
   markAllNotificationsAsRead: [UserNotification!]!
 
   sharePath(path: String!, userId: ID!): Boolean!
+
+  setPortal(portal: String!): User!
 }
 
 enum GrantHolderType {
@@ -473,7 +475,7 @@ enum ContractStatus {
 
 type TermsAndConditions {
   commencementDate: LocalDate!
-  displayName: String!
+  displayName: String!,
   url: String!
 }
 
@@ -640,7 +642,7 @@ type UnknownIncentive {
 }
 
 union Incentive =
-    MonthlyPercentageDiscountFixedPeriod
+  MonthlyPercentageDiscountFixedPeriod
   | FreeMonths
   | CostDeduction
   | NoDiscount

--- a/schema.graphql
+++ b/schema.graphql
@@ -473,7 +473,7 @@ enum ContractStatus {
 
 type TermsAndConditions {
   commencementDate: LocalDate!
-  displayName: String!,
+  displayName: String!
   url: String!
 }
 

--- a/src/auth/PortalsPage.tsx
+++ b/src/auth/PortalsPage.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { AvailablePortals } from 'auth/components/AvailablePortals'
+import { FadeIn, Flex, MainHeadline } from '@hedvig-ui'
+import { useAuthenticationQuery } from 'types/generated/graphql'
+import { useHistory } from 'react-router'
+
+export const PortalsPage: React.FC = () => {
+  const history = useHistory()
+  const { data } = useAuthenticationQuery()
+
+  const portals = data?.me.availablePortals ?? []
+  const currentPortal = data?.me.portal ?? ''
+
+  if (data?.me && portals.length <= 1) {
+    history.push('/')
+    return null
+  }
+
+  return (
+    <>
+      <FadeIn
+        style={{
+          marginTop: 'calc(35vh - 2rem)',
+          marginBottom: '2rem',
+          textAlign: 'center',
+        }}
+      >
+        <MainHeadline>Portals</MainHeadline>
+      </FadeIn>
+      <Flex justify="center" fullWidth>
+        <AvailablePortals
+          portals={portals}
+          currentPortal={currentPortal}
+          maxWidth="80vh"
+        />
+      </Flex>
+    </>
+  )
+}

--- a/src/auth/components/AvailablePortals.tsx
+++ b/src/auth/components/AvailablePortals.tsx
@@ -1,0 +1,146 @@
+import React from 'react'
+import styled from '@emotion/styled'
+import { css } from '@emotion/react'
+import chroma from 'chroma-js'
+import { useSetPortalMutation } from 'types/generated/graphql'
+import { useHistory } from 'react-router'
+import { FadeIn } from '@hedvig-ui'
+
+const PortalCard = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  width: 18rem;
+  height: 9rem;
+
+  padding: 0.8rem 0.8rem 0.8rem 1rem;
+
+  border-radius: 0.5rem;
+  margin-right: 1rem;
+  margin-bottom: 1rem;
+
+  ${({ theme }) => css`
+    background: ${chroma(theme.foreground).brighten(0.5).hex()};
+    color: ${theme.backgroundLight};
+  `};
+
+  div:first-of-type {
+    font-size: 1.6rem;
+    font-weight: bold;
+  }
+
+  transition: background-color 200ms ease-in-out;
+
+  div:nth-of-type(2) {
+    transition: opacity 200ms ease-in-out;
+    font-size: 1.05rem;
+    line-height: 1.25rem;
+    color: ${({ theme }) => chroma(theme.background).darken(1.5).hex()};
+    opacity: 0;
+  }
+
+  div:last-of-type {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  :hover {
+    div:nth-of-type(2) {
+      opacity: 1;
+    }
+  }
+
+  cursor: pointer;
+
+  :hover {
+    background-color: ${({ theme }) =>
+      chroma(theme.foreground).brighten(1).hex()};
+  }
+`
+
+const ActiveBadge = styled.span`
+  background-color: ${({ theme }) => theme.highlight};
+  color: ${({ theme }) => theme.background};
+  border-radius: 0.25rem;
+  padding: 0.2rem 0.5rem;
+`
+
+const ActivateBadge = styled.span`
+  color: ${({ theme }) => theme.background};
+  padding: 0.2rem 0.5rem;
+  text-decoration: underline;
+`
+
+type Portal = 'HOPE' | 'SOS'
+
+const descriptions: Record<Portal, string> = {
+  HOPE: 'The primary claims and member management tool',
+  SOS: 'Restricted member lookup used by SOS International',
+}
+
+const displayNames: Record<Portal, string> = {
+  HOPE: 'Hope',
+  SOS: 'SOS',
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+`
+
+export const AvailablePortals: React.FC<{
+  portals: string[]
+  currentPortal: string
+  maxWidth?: string
+}> = ({ portals, currentPortal, maxWidth }) => {
+  const history = useHistory()
+  const [setPortal] = useSetPortalMutation()
+
+  if (portals.length <= 1) {
+    return null
+  }
+
+  return (
+    <Container style={{ maxWidth }}>
+      {portals.map((portal, index) => (
+        <FadeIn duration={1000} delay={`${index * 100}ms`}>
+          <PortalCard
+            key={portal}
+            onClick={() => {
+              if (currentPortal === portal) {
+                history.push('/')
+                return
+              }
+
+              if (
+                window.confirm(
+                  `Are you sure you want to go to the ${
+                    displayNames[portal] ?? portal
+                  } portal?`,
+                )
+              ) {
+                setPortal({ variables: { portal } }).then(() => {
+                  history.push('/')
+                  window.location.reload()
+                })
+              }
+            }}
+          >
+            <div>{displayNames[portal] ?? portal}</div>
+            <div>{descriptions[portal] ?? portal}</div>
+            <div>
+              {currentPortal === portal ? (
+                <ActiveBadge>current</ActiveBadge>
+              ) : (
+                <ActivateBadge>activate</ActivateBadge>
+              )}
+            </div>
+          </PortalCard>
+        </FadeIn>
+      ))}
+    </Container>
+  )
+}

--- a/src/auth/graphql/authentication.graphql
+++ b/src/auth/graphql/authentication.graphql
@@ -1,0 +1,6 @@
+query Authentication {
+  me {
+    role
+    portal
+  }
+}

--- a/src/auth/graphql/authentication.graphql
+++ b/src/auth/graphql/authentication.graphql
@@ -2,5 +2,6 @@ query Authentication {
   me {
     role
     portal
+    availablePortals
   }
 }

--- a/src/auth/graphql/set-portal.graphql
+++ b/src/auth/graphql/set-portal.graphql
@@ -1,0 +1,5 @@
+mutation SetPortal($portal: String!) {
+  setPortal(portal: $portal) {
+    id
+  }
+}

--- a/src/auth/use-authenticate.ts
+++ b/src/auth/use-authenticate.ts
@@ -1,16 +1,19 @@
-import { Me, useGetMeQuery } from 'types/generated/graphql'
+import { useAuthenticationQuery } from 'types/generated/graphql'
 import { useEffect, useState } from 'react'
+import { ApolloError } from '@apollo/client'
 
 interface UseAuthenticateResult {
-  me?: Me
+  role: string | null
+  portal: string | null
   loading: boolean
+  error: ApolloError | null
 }
 
 export const useAuthenticate = (): UseAuthenticateResult => {
   const maxRefetchAttempts = 5
 
   const [refetchAttempt, setRefetchAttempt] = useState(0)
-  const { data, loading } = useGetMeQuery({
+  const { data, loading, error } = useAuthenticationQuery({
     pollInterval: 3000,
   })
 
@@ -28,12 +31,17 @@ export const useAuthenticate = (): UseAuthenticateResult => {
   }, [data, loading])
 
   if (loading) {
-    return { loading: true }
+    return { loading: true, portal: null, role: null, error: null }
   }
 
   if (data?.me) {
-    return { me: data.me as Me, loading: false }
+    return {
+      portal: data.me.portal,
+      role: data.me.portal,
+      loading: false,
+      error: null,
+    }
   }
 
-  return { loading: false }
+  return { portal: null, role: null, loading: false, error: error ?? null }
 }

--- a/src/auth/use-authenticate.ts
+++ b/src/auth/use-authenticate.ts
@@ -43,5 +43,10 @@ export const useAuthenticate = (): UseAuthenticateResult => {
     }
   }
 
-  return { portal: null, role: null, loading: false, error: error ?? null }
+  return {
+    portal: null,
+    role: null,
+    loading: false,
+    error: refetchAttempt > 5 && error ? error : null,
+  }
 }

--- a/src/auth/use-authenticate.ts
+++ b/src/auth/use-authenticate.ts
@@ -5,6 +5,7 @@ import { ApolloError } from '@apollo/client'
 interface UseAuthenticateResult {
   role: string | null
   portal: string | null
+  availablePortals: string[]
   loading: boolean
   error: ApolloError | null
 }
@@ -31,7 +32,13 @@ export const useAuthenticate = (): UseAuthenticateResult => {
   }, [data, loading])
 
   if (loading) {
-    return { loading: true, portal: null, role: null, error: null }
+    return {
+      loading: true,
+      portal: null,
+      role: null,
+      error: null,
+      availablePortals: data?.me.availablePortals ?? [],
+    }
   }
 
   if (data?.me) {
@@ -40,6 +47,7 @@ export const useAuthenticate = (): UseAuthenticateResult => {
       role: data.me.portal,
       loading: false,
       error: null,
+      availablePortals: data?.me.availablePortals ?? [],
     }
   }
 
@@ -48,5 +56,6 @@ export const useAuthenticate = (): UseAuthenticateResult => {
     role: null,
     loading: false,
     error: refetchAttempt > 5 && error ? error : null,
+    availablePortals: data?.me.availablePortals ?? [],
   }
 }

--- a/src/clientEntry.tsx
+++ b/src/clientEntry.tsx
@@ -10,12 +10,18 @@ import { Global } from '@emotion/react'
 import { DarkmodeProvider } from '@hedvig-ui/hooks/use-darkmode'
 import { GlobalStyles } from '@hedvig-ui/themes'
 import { useAuthenticate } from 'auth/use-authenticate'
+import { Route, Router, Switch } from 'react-router'
 
 export const history =
   typeof window !== 'undefined' ? createBrowserHistory() : createMemoryHistory()
 
 const App: React.FC = () => {
-  const { portal } = useAuthenticate()
+  const { portal, error } = useAuthenticate()
+
+  if (error) {
+    window.location.pathname = '/login/logout'
+    return null
+  }
 
   if (!portal) {
     return null
@@ -29,6 +35,23 @@ const App: React.FC = () => {
 ReactDOM.render(
   <CookiesProvider>
     <BrowserRouter>
+      <Router history={history}>
+        <Switch>
+          <Route
+            path="/gatekeeper"
+            exact
+            component={() => {
+              console.log('What')
+              window.location.href = `${
+                (window as any).GATEKEEPER_HOST
+              }/sso?redirect=${window.location.protocol}//${
+                window.location.host
+              }/login/callback`
+              return null
+            }}
+          />
+        </Switch>
+      </Router>
       <ApolloProvider client={apolloClient!}>
         <Global styles={GlobalStyles} />
         <DarkmodeProvider>

--- a/src/clientEntry.tsx
+++ b/src/clientEntry.tsx
@@ -9,11 +9,22 @@ import { app } from 'portals'
 import { Global } from '@emotion/react'
 import { DarkmodeProvider } from '@hedvig-ui/hooks/use-darkmode'
 import { GlobalStyles } from '@hedvig-ui/themes'
-
-const App = app('Hope')
+import { useAuthenticate } from 'auth/use-authenticate'
 
 export const history =
   typeof window !== 'undefined' ? createBrowserHistory() : createMemoryHistory()
+
+const App: React.FC = () => {
+  const { portal } = useAuthenticate()
+
+  if (!portal) {
+    return null
+  }
+
+  const Portal = app(portal)
+
+  return Portal ? <Portal /> : null
+}
 
 ReactDOM.render(
   <CookiesProvider>

--- a/src/clientEntry.tsx
+++ b/src/clientEntry.tsx
@@ -3,7 +3,6 @@ import { createBrowserHistory, createMemoryHistory } from 'history'
 import React from 'react'
 import { CookiesProvider } from 'react-cookie'
 import ReactDOM from 'react-dom'
-import { BrowserRouter } from 'react-router-dom'
 import { apolloClient } from 'server/apollo-client'
 import { app } from 'portals'
 import { Global } from '@emotion/react'
@@ -11,6 +10,7 @@ import { DarkmodeProvider } from '@hedvig-ui/hooks/use-darkmode'
 import { GlobalStyles } from '@hedvig-ui/themes'
 import { useAuthenticate } from 'auth/use-authenticate'
 import { Route, Router, Switch } from 'react-router'
+import { PortalsPage } from 'auth/PortalsPage'
 
 export const history =
   typeof window !== 'undefined' ? createBrowserHistory() : createMemoryHistory()
@@ -34,31 +34,30 @@ const App: React.FC = () => {
 
 ReactDOM.render(
   <CookiesProvider>
-    <BrowserRouter>
-      <Router history={history}>
-        <Switch>
-          <Route
-            path="/gatekeeper"
-            exact
-            component={() => {
-              window.location.href = `${
-                (window as any).GATEKEEPER_HOST
-              }/sso?redirect=${window.location.protocol}//${
-                window.location.host
-              }/login/callback`
-
-              return null
-            }}
-          />
-        </Switch>
-      </Router>
+    <Router history={history}>
       <ApolloProvider client={apolloClient!}>
-        <Global styles={GlobalStyles} />
         <DarkmodeProvider>
-          <App />
+          <Global styles={GlobalStyles} />
+          <Switch>
+            <Route exact path="/portals" component={PortalsPage} />
+            <Route
+              exact
+              path="/gatekeeper"
+              component={() => {
+                window.location.href = `${
+                  (window as any).GATEKEEPER_HOST
+                }/sso?redirect=${window.location.protocol}//${
+                  window.location.host
+                }/login/callback`
+
+                return null
+              }}
+            />
+            <Route component={App} />
+          </Switch>
         </DarkmodeProvider>
       </ApolloProvider>
-    </BrowserRouter>
+    </Router>
   </CookiesProvider>,
   document.getElementById('react-root'),
 )

--- a/src/clientEntry.tsx
+++ b/src/clientEntry.tsx
@@ -41,12 +41,12 @@ ReactDOM.render(
             path="/gatekeeper"
             exact
             component={() => {
-              console.log('What')
               window.location.href = `${
                 (window as any).GATEKEEPER_HOST
               }/sso?redirect=${window.location.protocol}//${
                 window.location.host
               }/login/callback`
+
               return null
             }}
           />

--- a/src/portals/hope/App.tsx
+++ b/src/portals/hope/App.tsx
@@ -21,7 +21,7 @@ import React, { useEffect } from 'react'
 import TagManager from 'react-gtm-module'
 import { hot } from 'react-hot-loader/root'
 import { Toaster } from 'react-hot-toast'
-import { Router, Switch } from 'react-router'
+import { Switch } from 'react-router'
 import { NavigationProvider } from '@hedvig-ui/hooks/navigation/use-navigation'
 
 const Layout = styled(BaseStyle)`
@@ -92,38 +92,34 @@ const App: React.FC = () => {
       <TrackingProvider>
         <MemberHistoryProvider>
           <NumberMemberGroupsProvider>
-            <Router history={history}>
-              <MeProvider me={me}>
-                <CommandLineProvider>
-                  <ConfirmDialogProvider>
-                    <Layout>
-                      <Tracker />
-                      {!history.location.pathname.startsWith('/login') && (
-                        <VerticalMenu history={history} />
-                      )}
-                      <Main
-                        dark={history.location.pathname.startsWith('/login')}
-                      >
-                        <TopBar />
-                        <MainContent>
-                          <Switch>
-                            <Routes />
-                          </Switch>
-                          <Toaster
-                            position="top-center"
-                            toastOptions={{
-                              style: {
-                                padding: '20px 25px',
-                              },
-                            }}
-                          />
-                        </MainContent>
-                      </Main>
-                    </Layout>
-                  </ConfirmDialogProvider>
-                </CommandLineProvider>
-              </MeProvider>
-            </Router>
+            <MeProvider me={me}>
+              <CommandLineProvider>
+                <ConfirmDialogProvider>
+                  <Layout>
+                    <Tracker />
+                    {!history.location.pathname.startsWith('/login') && (
+                      <VerticalMenu history={history} />
+                    )}
+                    <Main dark={history.location.pathname.startsWith('/login')}>
+                      <TopBar />
+                      <MainContent>
+                        <Switch>
+                          <Routes />
+                        </Switch>
+                        <Toaster
+                          position="top-center"
+                          toastOptions={{
+                            style: {
+                              padding: '20px 25px',
+                            },
+                          }}
+                        />
+                      </MainContent>
+                    </Main>
+                  </Layout>
+                </ConfirmDialogProvider>
+              </CommandLineProvider>
+            </MeProvider>
           </NumberMemberGroupsProvider>
         </MemberHistoryProvider>
       </TrackingProvider>

--- a/src/portals/hope/App.tsx
+++ b/src/portals/hope/App.tsx
@@ -21,7 +21,7 @@ import React, { useEffect } from 'react'
 import TagManager from 'react-gtm-module'
 import { hot } from 'react-hot-loader/root'
 import { Toaster } from 'react-hot-toast'
-import { Route, Router, Switch } from 'react-router'
+import { Router, Switch } from 'react-router'
 import { NavigationProvider } from '@hedvig-ui/hooks/navigation/use-navigation'
 
 const Layout = styled(BaseStyle)`
@@ -74,12 +74,6 @@ const App: React.FC = () => {
     })
   }, [me])
 
-  const redirectToLogin = () => {
-    window.location.href = `${(window as any).GATEKEEPER_HOST}/sso?redirect=${
-      window.location.protocol
-    }//${window.location.host}/login/callback`
-  }
-
   if (loading) {
     return (
       <StandaloneMessage paddingTop="45vh" opacity={1}>
@@ -90,18 +84,7 @@ const App: React.FC = () => {
   }
 
   if (!me) {
-    return (
-      <Switch>
-        <Route
-          path="/login"
-          exact
-          component={() => {
-            redirectToLogin()
-            return null
-          }}
-        />
-      </Switch>
-    )
+    return null
   }
 
   return (

--- a/src/portals/hope/features/members-search/styles.tsx
+++ b/src/portals/hope/features/members-search/styles.tsx
@@ -113,6 +113,7 @@ export const MemberHistoryCardWrapper = styled(Link)<{ muted: boolean }>`
     `};
   }
 `
+
 export const MemberName = styled.span`
   display: block;
 `

--- a/src/portals/hope/features/user/graphql/get-me.graphql
+++ b/src/portals/hope/features/user/graphql/get-me.graphql
@@ -28,5 +28,7 @@ query GetMe {
       key
       value
     }
+    portal
+    availablePortals
   }
 }

--- a/src/portals/hope/pages/settings/ProfilePage.tsx
+++ b/src/portals/hope/pages/settings/ProfilePage.tsx
@@ -1,15 +1,27 @@
-import { Button, Flex, Input, Label, MainHeadline, Spacing } from '@hedvig-ui'
+import {
+  Button,
+  Flex,
+  Input,
+  Label,
+  MainHeadline,
+  Spacing,
+  ThirdLevelHeadline,
+} from '@hedvig-ui'
 import { useTitle } from '@hedvig-ui/hooks/use-title'
 import React, { useEffect, useState } from 'react'
 import { toast } from 'react-hot-toast'
 import { useGetMeQuery, useUpdateUserMutation } from 'types/generated/graphql'
 import { Page } from 'portals/hope/pages/routes'
+import { AvailablePortals } from 'auth/components/AvailablePortals'
 
 const ProfilePage: Page = () => {
   const { data } = useGetMeQuery()
   const [fullName, setFullName] = useState('')
   const [phoneNumber, setPhoneNumber] = useState<null | string>('')
   const [updateUser] = useUpdateUserMutation()
+
+  const portals = data?.me.availablePortals ?? []
+  const currentPortal = data?.me.portal ?? ''
 
   const handleSaveChanges = () => {
     if (!data) {
@@ -60,9 +72,10 @@ const ProfilePage: Page = () => {
 
   return (
     <>
+      <MainHeadline>Settings</MainHeadline>
+      <Spacing top="large" />
       <div>
-        <MainHeadline>Profile</MainHeadline>
-        <Spacing top />
+        <ThirdLevelHeadline>Profile</ThirdLevelHeadline>
         <Flex direction="column">
           <form
             style={{ width: '100%', maxWidth: '350px' }}
@@ -108,6 +121,13 @@ const ProfilePage: Page = () => {
               )}
             </Flex>
           </form>
+        </Flex>
+      </div>
+      <Spacing top="large" />
+      <div>
+        <ThirdLevelHeadline>Portals</ThirdLevelHeadline>
+        <Flex fullWidth>
+          <AvailablePortals portals={portals} currentPortal={currentPortal} />
         </Flex>
       </div>
     </>

--- a/src/portals/hope/pages/settings/ProfilePage.tsx
+++ b/src/portals/hope/pages/settings/ProfilePage.tsx
@@ -123,13 +123,20 @@ const ProfilePage: Page = () => {
           </form>
         </Flex>
       </div>
-      <Spacing top="large" />
-      <div>
-        <ThirdLevelHeadline>Portals</ThirdLevelHeadline>
-        <Flex fullWidth>
-          <AvailablePortals portals={portals} currentPortal={currentPortal} />
-        </Flex>
-      </div>
+      {portals.length > 1 && (
+        <>
+          <Spacing top="large" />
+          <div>
+            <ThirdLevelHeadline>Portals</ThirdLevelHeadline>
+            <Flex fullWidth>
+              <AvailablePortals
+                portals={portals}
+                currentPortal={currentPortal}
+              />
+            </Flex>
+          </div>
+        </>
+      )}
     </>
   )
 }

--- a/src/portals/index.ts
+++ b/src/portals/index.ts
@@ -1,13 +1,11 @@
 import { SOSHotApp } from 'portals/sos/App'
 import { HOPEHotApp } from 'portals/hope/App'
 
-type Portal = 'SOS' | 'Hope'
-
-export const app = (portal: Portal) => {
-  switch (portal) {
+export const app = (portal: string) => {
+  switch (portal.toUpperCase()) {
     case 'SOS':
       return SOSHotApp
-    case 'Hope':
+    case 'HOPE':
       return HOPEHotApp
   }
 }

--- a/src/portals/sos/App.tsx
+++ b/src/portals/sos/App.tsx
@@ -1,15 +1,9 @@
 import React from 'react'
 import { hot } from 'react-hot-loader/root'
-import { history } from 'clientEntry'
-import { Router } from 'react-router'
 import { Routes } from 'portals/sos/pages/routes'
 
 const App: React.FC = () => {
-  return (
-    <Router history={history}>
-      <Routes />
-    </Router>
-  )
+  return <Routes />
 }
 
 export const SOSHotApp = hot(App)

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -40,12 +40,12 @@ export const loginCallback: Middleware<object> = async (ctx) => {
   const refreshToken = getTokenFromQuery(ctx.request.query['refresh-token'])
   setTokenCookies(ctx, { accessToken, refreshToken })
 
-  ctx.redirect('/dashborad')
+  ctx.redirect('/')
 }
 
 export const logout: Middleware<object> = async (ctx) => {
   setTokenCookies(ctx, { accessToken: '', refreshToken: '' })
-  ctx.redirect('/login')
+  ctx.redirect('/gatekeeper')
 }
 
 export const refreshTokenCallback: Middleware<LoggingMiddleware> = async (


### PR DESCRIPTION
# Jira Issue: [IP-216](https://hedvig.atlassian.net/browse/IP-216)

## What & Why
- Refactoring of directory and component structure on top-level to centralize things like authentication
- Portals are only visible and applicable if the role permits at least 2 portals. If only 1 is available, it's not possible to choose any other and the user won't even be exposed to the concept. The screenshots shown are from the perspective of a `Root` user. A SOS user will only see the SOS view, and IEX for example will only be able to see and use classic Hope.
- A global end-point `/portals` was added to facilitate debugging and eventually to be used instead of the current profile view (which might be replaced with just a button that routes to `/portals`). It's not accessible if only 1 portal is available.
- This feature is not really about SOS as much as it is about dissecting `hedgehog` into different, isolated internal products 

## Optional screenshots

https://user-images.githubusercontent.com/51323202/148962092-830678a5-36c7-4124-9b46-9f3be831dda5.mov


https://user-images.githubusercontent.com/51323202/148962274-9e9fa850-dd1c-4c22-9a9c-115bd0dad85b.mov


## Optional checklist
- [ ] Updated `src/changelog.ts`
- [x] Codescouted
- [ ] Unit tests written
- [x] Tested locally

