### PR TITLE
Fix: Lead window to renew access token

### DIFF
--- a/src/apollo/client.ts
+++ b/src/apollo/client.ts
@@ -9,6 +9,7 @@ import { persistenceMapper } from 'apollo/persistence/mapper'
 import { createPersistLink } from 'apollo/persistence/link'
 import gql from 'graphql-tag'
 import { BatchHttpLink } from '@apollo/client/link/batch-http'
+import { canRenewToken } from 'apollo/lock'
 
 gql`
   # Declare custom directive for IDE completion; don't want this to actually be resolved server-side
@@ -93,47 +94,11 @@ if (currentVersion === SCHEMA_VERSION) {
   localStorage.setItem(SCHEMA_VERSION_KEY, SCHEMA_VERSION)
 }
 
-/*
-const storeTokenRenewalDate = () => {
-  const RENEW_TOKEN_MINUTES = 10
-  const date = addMinutes(new Date(), RENEW_TOKEN_MINUTES)
-  localStorage.setItem('_tk_r', date.toISOString())
-}
-
-const renewAccessTokenLink = new ApolloLink((operation, forward) => {
-  const nextRefetch = localStorage.getItem('_tk_r')
-
-  if (!nextRefetch) {
-    storeTokenRenewalDate()
-
-    refreshAccessToken().catch((e) => {
-      console.error('Failed to refresh access token', e)
-      toast.loading('Authentication failed')
-      window.location.pathname = '/login/logout'
-    })
-    return forward(operation)
-  }
-
-  const parsedNextRefetch = parseISO(nextRefetch)
-
-  if (parsedNextRefetch < new Date()) {
-    storeTokenRenewalDate()
-    refreshAccessToken().catch((e) => {
-      console.error('Failed to refresh access token', e)
-      toast.loading('Authentication failed')
-      window.location.pathname = '/login/logout'
-    })
-  }
-
-  return forward(operation)
-})
-*/
-
 export const client = new ApolloClient({
   link: ApolloLink.from([
     onError((error) => {
       if (
-        document.hidden ||
+        !canRenewToken() ||
         ![401, 403].includes(
           (error?.networkError as ServerError)?.response?.status,
         )
@@ -147,7 +112,6 @@ export const client = new ApolloClient({
         window.location.pathname = '/login/logout'
       })
     }),
-    // renewAccessTokenLink, FIXME: Logs out the user if multiple tabs open when RT expires
     addTimezoneOffsetHeader,
     createPersistLink(),
     new BatchHttpLink({

--- a/src/apollo/lock.ts
+++ b/src/apollo/lock.ts
@@ -1,0 +1,49 @@
+import React, { useEffect } from 'react'
+import { v4 as uuidV4 } from 'uuid'
+
+/**
+ *  A component that generates a unique ID for the current window and registers itself as
+ *  the lead window to be responsible for renewing the access token. This guarantees that
+ *  at most one window will attempt to refresh when it expires.
+ *
+ *  It is to be mounted top-level and, most importantly, outside ApolloProvider which
+ *  instantiates the Apollo client.
+ *
+ *  How it works:
+ *      1. If it is the first mount of the window, register a unique id in session storage.
+ *         The scope of Session Storage is per window, so this won't be shared.
+ *      2. Register the same ID in local storage to assign this window as "lead"
+ *         If another window is opened, it will repeat the process but assign itself as "lead"
+ *      3. When the Access Token expires, the window will first check whether it's the lead window.
+ *         If it is, it will renew the access token. If not, it won't do anything.
+ *
+ */
+
+const LOCAL_STORAGE_KEY = '_window_lead_id'
+const SESSION_STORAGE_KEY = '_window_id'
+
+export const RenewTokenLock: React.FC = () => {
+  useEffect(() => {
+    const id = sessionStorage.getItem(SESSION_STORAGE_KEY)
+
+    if (!id) {
+      const newId = uuidV4()
+
+      sessionStorage.setItem(SESSION_STORAGE_KEY, newId)
+      localStorage.setItem(LOCAL_STORAGE_KEY, newId)
+    }
+  }, [])
+
+  return null
+}
+
+export const canRenewToken = () => {
+  const windowId = sessionStorage.getItem(SESSION_STORAGE_KEY)
+  const leadWindowId = localStorage.getItem(LOCAL_STORAGE_KEY)
+
+  if (!windowId || !leadWindowId) {
+    return false
+  }
+
+  return windowId === leadWindowId
+}

--- a/src/apollo/lock.ts
+++ b/src/apollo/lock.ts
@@ -24,21 +24,19 @@ const SESSION_STORAGE_WINDOW_ID_KEY = '_window_id'
 
 export const RenewTokenLock: React.FC = () => {
   useEffect(() => {
-    const oldSessionIdMaybe = sessionStorage.getItem(
-      SESSION_STORAGE_WINDOW_ID_KEY,
-    )
+    let sessionId = sessionStorage.getItem(SESSION_STORAGE_WINDOW_ID_KEY)
 
-    if (!oldSessionIdMaybe) {
-      const sessionId = uuidV4()
+    if (!sessionId) {
+      sessionId = uuidV4()
 
       sessionStorage.setItem(SESSION_STORAGE_WINDOW_ID_KEY, sessionId)
       localStorage.setItem(LOCAL_STORAGE_LEAD_WINDOW_ID_KEY, sessionId)
+    }
 
-      return () => {
-        const leadId = localStorage.getItem(LOCAL_STORAGE_LEAD_WINDOW_ID_KEY)
-        if (leadId === sessionId) {
-          localStorage.removeItem(LOCAL_STORAGE_LEAD_WINDOW_ID_KEY)
-        }
+    window.onbeforeunload = () => {
+      const leadId = localStorage.getItem(LOCAL_STORAGE_LEAD_WINDOW_ID_KEY)
+      if (leadId === sessionId) {
+        localStorage.removeItem(LOCAL_STORAGE_LEAD_WINDOW_ID_KEY)
       }
     }
   }, [])
@@ -56,12 +54,7 @@ export const canRenewToken = () => {
   }
 
   if (!windowId || !leadWindowId) {
-    const sessionId = uuidV4()
-
-    sessionStorage.setItem(SESSION_STORAGE_WINDOW_ID_KEY, sessionId)
-    localStorage.setItem(LOCAL_STORAGE_LEAD_WINDOW_ID_KEY, sessionId)
-
-    return true
+    return false
   }
 
   return windowId === leadWindowId

--- a/src/entry.tsx
+++ b/src/entry.tsx
@@ -12,6 +12,7 @@ import { useAuthenticate } from 'auth/use-authenticate'
 import { Route, Router, Switch } from 'react-router'
 import { PortalsPage } from 'auth/PortalsPage'
 import { Spinner, StandaloneMessage } from '@hedvig-ui'
+import { RenewTokenLock } from 'apollo/lock'
 
 export const history =
   typeof window !== 'undefined' ? createBrowserHistory() : createMemoryHistory()
@@ -41,6 +42,7 @@ const App: React.FC = () => {
 ReactDOM.render(
   <CookiesProvider>
     <Router history={history}>
+      <RenewTokenLock />
       <ApolloProvider client={client}>
         <DarkmodeProvider>
           <Global styles={GlobalStyles} />

--- a/src/portals/hope/features/search/components/SearchInput.tsx
+++ b/src/portals/hope/features/search/components/SearchInput.tsx
@@ -16,7 +16,6 @@ const SuggestionText = styled.div`
   font-size: 18px;
   opacity: 0.25;
   pointer-events: none;
-  margin-bottom: -2.86rem;
 `
 
 export const SearchInput: React.FC<{

--- a/src/portals/hope/pages/tasks/TasksPage.tsx
+++ b/src/portals/hope/pages/tasks/TasksPage.tsx
@@ -126,12 +126,12 @@ const ListContainer = styled.div`
 
 const ListItem = styled.div<{ selected?: boolean }>`
   display: flex;
-  font-size: 1rem;
-  padding: 1.2rem 2.05rem;
+  font-size: 1.1rem;
+  padding: 1.75rem 2.05rem;
   cursor: pointer;
 
   transition: background-color 200ms;
-
+  border-bottom: 1px solid rgba(0, 0, 0, 0.03);
   :hover {
     background-color: ${({ theme }) =>
       chroma(theme.accent).alpha(0.2).brighten(2).hex()};


### PR DESCRIPTION
## What?
A component that generates a unique ID for the current window and registers itself as the lead window to be responsible for renewing the access token. This guarantees that at most one window will attempt to refresh when it expires. It is to be mounted top-level and, most importantly, outside `ApolloProvider` which instantiates the Apollo client.

## How it works
1. If it is the first mount of the window, register a unique ID for the window in session storage. The scope of Session Storage is per window, so this won't be shared.
2. Register the same ID in local storage to assign this window as "lead". If another window is opened, it will repeat the process but assign itself as "lead" instead.
3. When the Access Token expires, the window will first check whether it's the lead window. If it is, it will renew the access token. If not, it won't do anything.
4. Profit